### PR TITLE
test: add two-tier test suite (integration tests + E2E tests)

### DIFF
--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -1,0 +1,189 @@
+# End-to-End (E2E) Tests
+
+## Overview
+
+E2E tests verify that the **fully packaged jmxterm uber JAR** works correctly as a standalone application. Unlike integration tests (which call `CommandCenter` directly in-process), E2E tests launch jmxterm as a **separate OS process**, pipe commands to its stdin, and verify its stdout output and exit codes.
+
+This tests the real user experience: CLI argument parsing, non-interactive mode, file I/O, auto-connect, and process exit behavior — none of which can be tested in-process.
+
+## How they run
+
+E2E tests live in:
+
+```
+src/test/java/org/cyclopsgroup/jmxterm/e2e/
+```
+
+Like integration tests, they use the `*IT.java` naming convention and run via the Maven Failsafe plugin during `mvn verify`:
+
+```bash
+# Run all tests (unit + integration + e2e)
+mvn verify
+
+# Run a single e2e test class
+mvn verify -Dit.test=ScriptExecutionE2EIT
+
+# Run a single e2e test method
+mvn verify -Dit.test=ExitCodeE2EIT#testSuccessfulExecution
+```
+
+E2E tests depend on the uber JAR existing in `target/`, which is built during the `package` phase — Failsafe's `integration-test` phase runs after `package`, so the JAR is always available.
+
+E2E tests run on every PR via CI, across JDK 17, 21, and 25.
+
+## Architecture
+
+E2E tests involve **two separate JVM processes** communicating over JMX:
+
+```
+┌─────────────────────┐         JMX/RMI          ┌──────────────────────┐
+│   jmxterm process    │ ◄──────────────────────► │  target JVM process  │
+│                      │    localhost:<port>       │                      │
+│  (uber JAR, -n mode) │                          │  (TestTargetApp)     │
+│  stdin ← test sends  │                          │  MBean: test:type=   │
+│  stdout → test reads  │                          │    TestMBean         │
+└─────────────────────┘                           └──────────────────────┘
+         ▲                                                  ▲
+         │              ┌──────────────────┐                │
+         └──────────────│   JUnit test     │────────────────┘
+                        │  (test process)  │
+                        │  manages both    │
+                        │  subprocesses    │
+                        └──────────────────┘
+```
+
+### TestTargetApp — the JMX target
+
+`TestTargetApp` is a minimal Java main class that:
+
+1. Gets the platform `MBeanServer`
+2. Registers a `TestMBean` (with String/int attributes and echo/add/reset operations)
+3. Prints `"READY"` to stdout to signal it's ready for connections
+4. Blocks on `System.in.read()` — stays alive until the test closes its stdin
+
+The MBean interface and implementation are **nested inside TestTargetApp** to avoid classpath issues — since this class runs as a subprocess, it can only access classes on its own classpath.
+
+### TargetJvmProcess — launching the target
+
+`TargetJvmProcess` manages the `TestTargetApp` subprocess lifecycle:
+
+1. Finds a free TCP port using `new ServerSocket(0)`
+2. Launches a JVM with JMX remote enabled:
+   ```
+   java -cp <classpath>
+        -Dcom.sun.management.jmxremote
+        -Dcom.sun.management.jmxremote.port=<port>
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+        -Dcom.sun.management.jmxremote.local.only=true
+        org.cyclopsgroup.jmxterm.e2e.TestTargetApp
+   ```
+3. Waits for the `"READY"` line on stdout before returning
+
+Tests use it via `@BeforeAll` / `@AfterAll`:
+
+```java
+private static TargetJvmProcess target;
+
+@BeforeAll
+static void startTarget() throws Exception {
+    target = new TargetJvmProcess();
+    target.waitUntilReady(Duration.ofSeconds(30));
+}
+
+@AfterAll
+static void stopTarget() {
+    if (target != null) target.close();
+}
+```
+
+Key methods:
+- `getJmxPort()` — the port to connect to
+- `getPid()` — the OS process ID
+- `close()` — forcibly destroys the process
+
+### JmxTermProcessHelper — launching jmxterm
+
+`JmxTermProcessHelper` manages a jmxterm subprocess:
+
+1. Finds the uber JAR in `target/` (matches `jmxterm-*-uber.jar`)
+2. Launches: `java -jar <uber.jar> -n [extra args]`
+   - `-n` enables non-interactive mode (reads plain stdin, no JLine)
+3. Provides methods to send commands and read output
+
+```java
+try (JmxTermProcessHelper jmx = new JmxTermProcessHelper("-v", "silent")) {
+    jmx.sendCommand("open localhost:" + target.getJmxPort());
+    jmx.sendCommand("domains");
+    String output = jmx.readAllOutput(Duration.ofSeconds(10));
+    assertTrue(output.contains("JMImplementation"));
+}
+```
+
+Key methods:
+- `sendCommand(String)` — sends a single command line to stdin
+- `sendCommandAndClose(String...)` — sends multiple commands, then closes stdin (triggers EOF → exit)
+- `readAllOutput(Duration timeout)` — closes stdin, waits for the process to exit, returns all stdout
+- `getExitCode()` — returns the process exit code after it has terminated
+- `close()` — forcibly destroys the process if still running
+
+## What is tested
+
+### ScriptExecutionE2EIT (4 tests)
+
+Tests full command workflows by piping commands to the jmxterm process.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testBasicCommandExecution` | Opens connection, runs `domains`, verifies domain names appear in output |
+| `testGetAttribute` | Opens, selects bean, runs `get Name`, verifies `"default"` in output |
+| `testSetAndGetAttribute` | Sets `Name` to `"hello"`, gets it back, verifies the new value |
+| `testRunOperation` | Invokes `run echo world`, verifies `"echo:world"` in output |
+
+### CliArgumentsE2EIT (4 tests)
+
+Tests CLI flags that control jmxterm's startup behavior.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testAutoConnect` | `-l localhost:<port>` auto-connects on startup; `domains` works immediately |
+| `testSilentMode` | `-v silent` suppresses all `#`-prefixed messages but still shows result values |
+| `testExitOnFailure` | `-e` causes jmxterm to exit with non-zero code on first command failure |
+| `testHelpFlag` | `-h` prints usage information and exits with code 0 |
+
+### ExitCodeE2EIT (3 tests)
+
+Tests the process exit code under different scenarios.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testSuccessfulExecution` | Normal flow (open → domains → quit) exits with code 0 |
+| `testExitOnFailureReturnsNegativeLineNumber` | With `-e`, a failure on line N causes exit code -N (254 unsigned on POSIX) |
+| `testQuitExitCode` | Just sending `quit` exits with code 0 |
+
+## Port allocation
+
+Both `TargetJvmProcess` and the test infrastructure use **random free ports** (`new ServerSocket(0)`) to avoid conflicts. This is important because:
+
+- Multiple test classes may run in parallel
+- CI runners may have other services using fixed ports
+- Tests must not interfere with each other
+
+## Process lifecycle and cleanup
+
+Every process is forcibly destroyed in `@AfterAll` or in `close()` methods. `JmxTermProcessHelper` implements `AutoCloseable` so it can be used in try-with-resources blocks.
+
+The target JVM stays alive for all tests in a class (started in `@BeforeAll`, stopped in `@AfterAll`), while each test creates its own fresh jmxterm process to ensure clean state.
+
+## Differences from integration tests
+
+| Aspect | Integration tests | E2E tests |
+|--------|------------------|-----------|
+| JMX server | Embedded in test JVM | Separate subprocess |
+| jmxterm | `CommandCenter` called directly | Uber JAR launched as process |
+| Communication | In-process method calls | stdin/stdout pipes + JMX/RMI |
+| What's tested | Command logic, JMX protocol | CLI args, packaging, exit codes |
+| Speed | Fast (~50ms per test) | Slower (~200ms per test, process startup) |
+| Failure diagnosis | Stack traces in test output | Process stdout/stderr capture |
+
+Both tiers complement each other: integration tests catch command logic bugs quickly, while E2E tests verify the packaged application works as users would run it.

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,0 +1,210 @@
+# Integration Tests
+
+## Overview
+
+Integration tests verify that jmxterm commands work correctly against a **real JMX server**. Unlike the unit tests (which mock `MBeanServerConnection`), these tests start an actual JMX connector server inside the test JVM and execute commands over a real JMX/RMI connection.
+
+This means the tests exercise the full command lifecycle: argument parsing → command dispatch → JMX protocol call → result formatting → output.
+
+## How they run
+
+Integration tests live in:
+
+```
+src/test/java/org/cyclopsgroup/jmxterm/integration/
+```
+
+They use the `*IT.java` naming convention and are executed by the **Maven Failsafe plugin** during the `integration-test` phase. This means they run as part of `mvn verify`, not `mvn test`:
+
+```bash
+# Run all tests (unit + integration + e2e)
+mvn verify
+
+# Run a single integration test class
+mvn verify -Dit.test=AttributeReadWriteIT
+
+# Run a single integration test method
+mvn verify -Dit.test=ConnectionLifecycleIT#testOpenConnection
+```
+
+Integration tests run on every PR via the existing CI workflow (`maven.yaml`), across JDK 17, 21, and 25.
+
+## Architecture
+
+### The embedded JMX server
+
+The key piece of infrastructure is `EmbeddedJmxServer`, a JUnit 5 extension that:
+
+1. Finds a free TCP port
+2. Creates a dedicated `MBeanServer` (isolated from the platform MBeanServer)
+3. Registers a test MBean under `test:type=TestMBean`
+4. Creates an RMI registry on the chosen port
+5. Starts a `JMXConnectorServer` bound to `localhost:<port>`
+
+This all happens once per test class (`@BeforeAll`). After all tests run, the server is torn down (`@AfterAll`).
+
+```java
+@RegisterExtension
+static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+```
+
+The server exposes helper methods used by tests:
+- `getPort()` — the random port
+- `getConnectionUrl()` — returns `"localhost:<port>"`, ready to pass to the `open` command
+- `getServiceUrl()` — full `service:jmx:rmi:///jndi/rmi://...` URL
+- `getMBeanServer()` — direct access for state reset between tests
+
+### The test MBean
+
+`TestMBean` / `TestMBeanImpl` is a simple MBean registered in the embedded server:
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `Name` | String attribute (read/write) | Initially `"default"` |
+| `Count` | int attribute (read-only) | Tracks how many times `setName()` was called |
+| `echo(String)` | operation | Returns `"echo:"` + input |
+| `add(int, int)` | operation | Returns the sum |
+| `reset()` | operation | Resets Name to `"default"` and Count to `0` |
+
+This gives tests a controllable MBean with readable, writable, and read-only attributes, plus operations with different signatures and return types.
+
+### Test pattern
+
+Each test class follows this pattern:
+
+```java
+@RegisterExtension
+static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+private StringWriter resultOutput;
+private StringWriter messageOutput;
+private CommandCenter cc;
+
+@BeforeEach
+void setUp() throws Exception {
+    resultOutput = new StringWriter();
+    messageOutput = new StringWriter();
+    cc = new CommandCenter(
+        new WriterCommandOutput(resultOutput, messageOutput), null);
+}
+
+@AfterEach
+void tearDown() {
+    cc.close();
+}
+
+@Test
+void testSomething() {
+    cc.execute("open " + jmxServer.getConnectionUrl());
+    cc.execute("bean test:type=TestMBean");
+    cc.execute("get Name");
+    assertTrue(resultOutput.toString().contains("default"));
+}
+```
+
+Key points:
+- **Fresh CommandCenter per test** — avoids state leaking between tests
+- **Two output writers** — `resultOutput` captures command values (what the user would see), `messageOutput` captures informational messages (prefixed with `#`)
+- **Direct MBeanServer access** — some tests call `jmxServer.getMBeanServer().invoke(...)` in `@AfterEach` to reset the test MBean's state
+
+## What is tested
+
+### ConnectionLifecycleIT (6 tests)
+
+Tests the JMX connection lifecycle managed by the `open` and `close` commands.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testOpenConnection` | A basic `open localhost:<port>` succeeds |
+| `testOpenDisplaysConnectionInfo` | Running `open` with no arguments prints the current connection's service URL |
+| `testCloseAndReconnect` | Opening, closing, then opening again works correctly |
+| `testOpenWhenAlreadyConnected` | Opening a second connection without closing first is rejected |
+| `testCloseWithoutOpen` | Closing when nothing is connected is a harmless no-op |
+| `testOpenWithFullServiceUrl` | Opening with a full `service:jmx:rmi:///...` URL works |
+
+### DomainBeanNavigationIT (6 tests)
+
+Tests browsing and selecting JMX domains and beans — the core navigation model of jmxterm.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testListDomains` | `domains` lists available domains (`test`, `JMImplementation`) |
+| `testSelectDomain` | `domain test` sets the current domain; `domain` (no args) displays it |
+| `testListBeans` | `beans` lists beans in the selected domain |
+| `testSelectBean` | `bean test:type=TestMBean` sets the current bean; `bean` (no args) displays it |
+| `testListBeansWithDomainOption` | `beans -d test` lists beans in a specific domain without changing the current domain |
+| `testInfoCommand` | `info` displays MBean metadata: attributes (Name, Count) and operations (echo, add, reset) |
+
+### AttributeReadWriteIT (8 tests)
+
+Tests reading and writing MBean attributes via the `get` and `set` commands.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testGetStringAttribute` | `get Name` returns `"default"` |
+| `testGetIntAttribute` | `get Count` returns `0` |
+| `testGetAllAttributes` | `get *` returns all attributes |
+| `testGetWithBeanOption` | `get -b test:type=TestMBean Name` works without selecting a bean first |
+| `testSetAndGetAttribute` | `set Name newValue` followed by `get Name` returns `"newValue"` |
+| `testSetAndVerifyCount` | After `set Name x`, the read-only `Count` attribute reflects the state change |
+| `testGetSimpleFormat` | `get -s Name` prints just the value (no `Name = ...` expression) |
+| `testGetNonExistentAttribute` | Getting a non-existent attribute produces no result output |
+
+### OperationInvocationIT (6 tests)
+
+Tests invoking MBean operations via the `run` command.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testRunEchoOperation` | `run echo hello` returns `"echo:hello"` |
+| `testRunAddOperation` | `run add 3 5` returns `8` |
+| `testRunResetOperation` | After changing state, `run reset` restores defaults |
+| `testRunWithBeanOption` | `run -b test:type=TestMBean echo world` works without selecting a bean first |
+| `testRunNonExistentOperation` | Invoking a non-existent operation fails |
+| `testRunWithWrongParamCount` | Passing the wrong number of parameters fails |
+
+### ErrorHandlingIT (6 tests)
+
+Tests that invalid usage produces clear failures rather than crashes.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testGetWithoutConnection` | `get Name` without an open connection fails |
+| `testGetWithoutBean` | `get Name` with a connection but no bean selected fails |
+| `testInvalidBeanName` | Using a malformed bean name fails |
+| `testConnectToBadPort` | `open localhost:1` (invalid port) fails |
+| `testDomainWithoutConnection` | `domains` without a connection fails |
+| `testSetReadOnlyAttribute` | `set Count 5` on a read-only attribute fails |
+
+### CommandChainingIT (5 tests)
+
+Tests jmxterm's command-line parsing features.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testCommandChaining` | `open ... && domains && beans -d test` executes all commands in sequence |
+| `testCommentHandling` | `domains # comment` executes the command, ignores the comment |
+| `testFullLineComment` | `# this is a comment` is silently skipped |
+| `testEscapedHash` | `\#` in a value is treated as a literal `#`, not a comment marker |
+| `testEmptyCommand` | An empty string is silently accepted |
+
+### VerboseLevelIT (5 tests)
+
+Tests how the verbose level (`SILENT`, `BRIEF`, `VERBOSE`) controls what the user sees.
+
+| Test | What it verifies |
+|------|-----------------|
+| `testBriefMessages` | In BRIEF mode (default), informational messages are shown with a `#` prefix |
+| `testSilentSuppressesMessages` | In SILENT mode, informational messages are completely suppressed |
+| `testSilentStillShowsValues` | In SILENT mode, command result values are still printed |
+| `testVerboseShowsStackTraces` | In VERBOSE mode, errors include full Java stack traces |
+| `testBriefShowsShortErrors` | In BRIEF mode, errors show a short `#`-prefixed message, not a stack trace |
+
+## Domains available in tests
+
+Because the embedded server uses `MBeanServerFactory.createMBeanServer()` (not the platform MBeanServer), only two domains exist:
+
+- **`JMImplementation`** — automatically created by the MBeanServer (contains `MBeanServerDelegate`)
+- **`test`** — contains our `test:type=TestMBean`
+
+This keeps tests deterministic — no interference from platform beans like `java.lang` or `java.nio`.

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,24 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>rpm-maven-plugin</artifactId>
         <version>${rpm-maven-plugin.version}</version>

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/CliArgumentsE2EIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/CliArgumentsE2EIT.java
@@ -1,0 +1,86 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** End-to-end integration tests for jmxterm CLI argument handling. */
+class CliArgumentsE2EIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static TargetJvmProcess targetJvm;
+
+  @BeforeAll
+  static void startTargetJvm() throws Exception {
+    targetJvm = new TargetJvmProcess();
+    targetJvm.waitUntilReady(TIMEOUT);
+  }
+
+  @AfterAll
+  static void stopTargetJvm() {
+    if (targetJvm != null) {
+      targetJvm.close();
+    }
+  }
+
+  @Test
+  void testAutoConnect() throws Exception {
+    try (JmxTermProcessHelper jmxterm =
+        new JmxTermProcessHelper("-l", "localhost:" + targetJvm.getJmxPort())) {
+      jmxterm.sendCommandAndClose("domains", "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertTrue(
+          output.contains("JMImplementation"),
+          "Expected 'JMImplementation' domain in output: " + output);
+    }
+  }
+
+  @Test
+  void testSilentMode() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-v", "silent")) {
+      jmxterm.sendCommandAndClose(
+          "open localhost:" + targetJvm.getJmxPort(),
+          "bean test:type=TestMBean",
+          "get Name",
+          "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      // In silent mode, informational messages prefixed with "#" should not appear
+      for (String line : output.split("\\R")) {
+        assertFalse(
+            line.startsWith("#"),
+            "Silent mode should not produce '#' prefixed lines, but found: " + line);
+      }
+      // The attribute value should still be present
+      assertTrue(output.contains("default"), "Expected 'default' value in output: " + output);
+    }
+  }
+
+  @Test
+  void testExitOnFailure() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-e")) {
+      // Send a command that fails (getting an attribute without a connection)
+      jmxterm.sendCommandAndClose("get Name");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      int exitCode = jmxterm.getExitCode();
+      assertNotEquals(0, exitCode, "Expected non-zero exit code for failed command, output: " + output);
+    }
+  }
+
+  @Test
+  void testHelpFlag() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-h")) {
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      int exitCode = jmxterm.getExitCode();
+      assertTrue(
+          output.contains("usage") || output.contains("Usage") || output.contains("jmxterm"),
+          "Expected usage information in output: " + output);
+      assertEquals(0, exitCode, "Help flag should result in exit code 0");
+    }
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/ExitCodeE2EIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/ExitCodeE2EIT.java
@@ -1,0 +1,65 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** End-to-end integration tests for jmxterm process exit codes. */
+class ExitCodeE2EIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static TargetJvmProcess targetJvm;
+
+  @BeforeAll
+  static void startTargetJvm() throws Exception {
+    targetJvm = new TargetJvmProcess();
+    targetJvm.waitUntilReady(TIMEOUT);
+  }
+
+  @AfterAll
+  static void stopTargetJvm() {
+    if (targetJvm != null) {
+      targetJvm.close();
+    }
+  }
+
+  @Test
+  void testSuccessfulExecution() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open localhost:" + targetJvm.getJmxPort(), "domains", "quit");
+      jmxterm.readAllOutput(TIMEOUT);
+      assertEquals(0, jmxterm.getExitCode(), "Successful execution should return exit code 0");
+    }
+  }
+
+  @Test
+  void testExitOnFailureReturnsNegativeLineNumber() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-e")) {
+      // Line 1: valid command (help), Line 2: invalid command (get without connection/bean)
+      jmxterm.sendCommandAndClose("help", "get Name");
+      jmxterm.readAllOutput(TIMEOUT);
+      int exitCode = jmxterm.getExitCode();
+      // System.exit(-2) produces 254 on POSIX (unsigned byte: 256 - 2)
+      assertTrue(
+          exitCode != 0,
+          "Expected non-zero exit code for failure with -e, but got: " + exitCode);
+      assertTrue(
+          exitCode == -2 || exitCode == 254,
+          "Exit code should be -2 (or 254 unsigned), but got: " + exitCode);
+    }
+  }
+
+  @Test
+  void testQuitExitCode() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose("quit");
+      jmxterm.readAllOutput(TIMEOUT);
+      assertEquals(0, jmxterm.getExitCode(), "Quit command should return exit code 0");
+    }
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/JmxTermProcessHelper.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/JmxTermProcessHelper.java
@@ -133,12 +133,14 @@ public class JmxTermProcessHelper implements AutoCloseable {
 
   private static Path findUberJar() throws IOException {
     Path targetDir = Path.of("target");
-    return Files.list(targetDir)
-        .filter(p -> p.getFileName().toString().matches("jmxterm-.*-uber\\.jar"))
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new IOException(
-                    "Uber JAR not found in target/. Run 'mvn package' first."));
+    try (var files = Files.list(targetDir)) {
+      return files
+          .filter(p -> p.getFileName().toString().matches("jmxterm-.*-uber\\.jar"))
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IOException(
+                      "Uber JAR not found in target/. Run 'mvn package' first."));
+    }
   }
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/JmxTermProcessHelper.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/JmxTermProcessHelper.java
@@ -1,0 +1,144 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Launches the jmxterm uber JAR as a subprocess in non-interactive mode and provides methods to
+ * send commands via stdin and read output from stdout.
+ */
+public class JmxTermProcessHelper implements AutoCloseable {
+
+  private final Process process;
+
+  /**
+   * Finds the uber JAR and launches jmxterm with {@code -n} (non-interactive) plus any extra
+   * arguments.
+   *
+   * @param extraArgs additional CLI arguments (e.g. {@code "-v", "silent"})
+   * @throws IOException if the JAR is not found or the process cannot be started
+   */
+  public JmxTermProcessHelper(String... extraArgs) throws IOException {
+    Path uberJar = findUberJar();
+    String javaHome = System.getProperty("java.home");
+    String javaBin = javaHome + "/bin/java";
+
+    List<String> command = new ArrayList<>();
+    command.add(javaBin);
+    command.add("-jar");
+    command.add(uberJar.toAbsolutePath().toString());
+    command.add("-n");
+    for (String arg : extraArgs) {
+      command.add(arg);
+    }
+
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.redirectErrorStream(true);
+    this.process = pb.start();
+  }
+
+  /**
+   * Sends a single command to jmxterm's stdin.
+   *
+   * @param command the command string (without newline)
+   * @throws IOException if writing fails
+   */
+  public void sendCommand(String command) throws IOException {
+    OutputStream stdin = process.getOutputStream();
+    stdin.write((command + "\n").getBytes(StandardCharsets.UTF_8));
+    stdin.flush();
+  }
+
+  /**
+   * Sends multiple commands and then closes stdin to signal EOF.
+   *
+   * @param commands the commands to send
+   * @throws IOException if writing fails
+   */
+  public void sendCommandAndClose(String... commands) throws IOException {
+    OutputStream stdin = process.getOutputStream();
+    for (String cmd : commands) {
+      stdin.write((cmd + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+    stdin.flush();
+    stdin.close();
+  }
+
+  /**
+   * Closes stdin (if still open), waits for the process to exit, and returns all stdout output.
+   *
+   * @param timeout maximum time to wait for the process to exit
+   * @return the complete stdout/stderr output
+   * @throws IOException if reading fails
+   * @throws IllegalStateException if the process does not exit within the timeout
+   */
+  public String readAllOutput(Duration timeout) throws IOException {
+    try {
+      process.getOutputStream().close();
+    } catch (IOException ignored) {
+      // stdin may already be closed
+    }
+
+    StringBuilder sb = new StringBuilder();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+    boolean exited;
+    try {
+      exited = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for jmxterm to exit", e);
+    }
+
+    String line;
+    while ((line = reader.readLine()) != null) {
+      sb.append(line).append(System.lineSeparator());
+    }
+
+    if (!exited) {
+      process.destroyForcibly();
+      throw new IllegalStateException(
+          "jmxterm did not exit within " + timeout.toSeconds() + " seconds");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Returns the exit code of the jmxterm process. The process must have already exited.
+   *
+   * @return the exit code
+   */
+  public int getExitCode() {
+    return process.exitValue();
+  }
+
+  @Override
+  public void close() {
+    process.destroyForcibly();
+    try {
+      process.waitFor(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static Path findUberJar() throws IOException {
+    Path targetDir = Path.of("target");
+    return Files.list(targetDir)
+        .filter(p -> p.getFileName().toString().matches("jmxterm-.*-uber\\.jar"))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IOException(
+                    "Uber JAR not found in target/. Run 'mvn package' first."));
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/ScriptExecutionE2EIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/ScriptExecutionE2EIT.java
@@ -1,0 +1,85 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration tests that launch jmxterm as a separate OS process, connect to a target
+ * JVM, and verify command output.
+ */
+class ScriptExecutionE2EIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static TargetJvmProcess targetJvm;
+
+  @BeforeAll
+  static void startTargetJvm() throws Exception {
+    targetJvm = new TargetJvmProcess();
+    targetJvm.waitUntilReady(TIMEOUT);
+  }
+
+  @AfterAll
+  static void stopTargetJvm() {
+    if (targetJvm != null) {
+      targetJvm.close();
+    }
+  }
+
+  @Test
+  void testBasicCommandExecution() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open localhost:" + targetJvm.getJmxPort(), "domains", "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      // The platform MBeanServer always exposes the JMImplementation domain
+      assertTrue(
+          output.contains("JMImplementation"),
+          "Expected 'JMImplementation' domain in output: " + output);
+    }
+  }
+
+  @Test
+  void testGetAttribute() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open localhost:" + targetJvm.getJmxPort(),
+          "bean test:type=TestMBean",
+          "run reset",
+          "get Name",
+          "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertTrue(output.contains("default"), "Expected 'default' in output: " + output);
+    }
+  }
+
+  @Test
+  void testSetAndGetAttribute() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open localhost:" + targetJvm.getJmxPort(),
+          "bean test:type=TestMBean",
+          "set Name hello",
+          "get Name",
+          "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertTrue(output.contains("hello"), "Expected 'hello' in output: " + output);
+    }
+  }
+
+  @Test
+  void testRunOperation() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open localhost:" + targetJvm.getJmxPort(),
+          "bean test:type=TestMBean",
+          "run echo world",
+          "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertTrue(output.contains("echo:world"), "Expected 'echo:world' in output: " + output);
+    }
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/TargetJvmProcess.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/TargetJvmProcess.java
@@ -3,10 +3,10 @@ package org.cyclopsgroup.jmxterm.e2e;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -16,16 +16,42 @@ import java.util.concurrent.TimeoutException;
  */
 public class TargetJvmProcess implements AutoCloseable {
 
+  private static final int MAX_PORT_RETRIES = 10;
+
   private final Process process;
   private final int jmxPort;
+  private volatile boolean ready;
 
   /**
-   * Starts the target JVM with JMX remote enabled on a random free port.
+   * Starts the target JVM with JMX remote enabled on a random port. Retries with a different port
+   * if the process fails to become ready (e.g. due to a port conflict).
    *
-   * @throws IOException if the process cannot be started
+   * @throws IOException if the process cannot be started after all retries
    */
   public TargetJvmProcess() throws IOException {
-    this.jmxPort = findFreePort();
+    int port = 0;
+    Process started = null;
+    for (int attempt = 0; attempt < MAX_PORT_RETRIES; attempt++) {
+      port = ThreadLocalRandom.current().nextInt(49152, 65536);
+      started = startProcess(port);
+      try {
+        waitUntilReady(started, Duration.ofSeconds(10));
+        break;
+      } catch (IllegalStateException e) {
+        started.destroyForcibly();
+        started = null;
+        if (attempt == MAX_PORT_RETRIES - 1) {
+          throw new IOException(
+              "Failed to start target JVM after " + MAX_PORT_RETRIES + " attempts", e);
+        }
+      }
+    }
+    this.jmxPort = port;
+    this.process = started;
+    this.ready = true;
+  }
+
+  private static Process startProcess(int port) throws IOException {
     String javaHome = System.getProperty("java.home");
     String javaBin = javaHome + "/bin/java";
     String classpath = System.getProperty("java.class.path");
@@ -36,24 +62,32 @@ public class TargetJvmProcess implements AutoCloseable {
             "-cp",
             classpath,
             "-Dcom.sun.management.jmxremote",
-            "-Dcom.sun.management.jmxremote.port=" + jmxPort,
+            "-Dcom.sun.management.jmxremote.port=" + port,
             "-Dcom.sun.management.jmxremote.authenticate=false",
             "-Dcom.sun.management.jmxremote.ssl=false",
             "-Dcom.sun.management.jmxremote.local.only=true",
             "org.cyclopsgroup.jmxterm.e2e.TestTargetApp");
     pb.redirectErrorStream(true);
-    this.process = pb.start();
+    return pb.start();
   }
 
   /**
-   * Waits until the target JVM prints "READY" to stdout.
+   * Waits until the target JVM prints "READY" to stdout. No-op if the process is already ready
+   * (readiness is established during construction via retry loop).
    *
-   * @param timeout maximum time to wait
-   * @throws IOException if reading stdout fails
+   * @param timeout maximum time to wait (ignored if already ready)
    * @throws IllegalStateException if the timeout expires before "READY" is received
    */
-  public void waitUntilReady(Duration timeout) throws IOException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+  public void waitUntilReady(Duration timeout) {
+    if (ready) {
+      return;
+    }
+    waitUntilReady(process, timeout);
+    ready = true;
+  }
+
+  private static void waitUntilReady(Process proc, Duration timeout) {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
     CompletableFuture<Boolean> future =
         CompletableFuture.supplyAsync(
             () -> {
@@ -72,19 +106,15 @@ public class TargetJvmProcess implements AutoCloseable {
     try {
       boolean ready = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
       if (!ready) {
-        process.destroyForcibly();
         throw new IllegalStateException("Target JVM exited without printing READY");
       }
     } catch (TimeoutException e) {
-      process.destroyForcibly();
       throw new IllegalStateException(
           "Target JVM did not become ready within " + timeout.toSeconds() + " seconds");
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      process.destroyForcibly();
       throw new IllegalStateException("Interrupted while waiting for target JVM", e);
     } catch (ExecutionException e) {
-      process.destroyForcibly();
       throw new IllegalStateException("Error while waiting for target JVM", e.getCause());
     }
   }
@@ -109,9 +139,5 @@ public class TargetJvmProcess implements AutoCloseable {
     }
   }
 
-  private static int findFreePort() throws IOException {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      return socket.getLocalPort();
-    }
-  }
+
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/TargetJvmProcess.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/TargetJvmProcess.java
@@ -1,0 +1,117 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Launches {@link TestTargetApp} as a subprocess with JMX remote enabled. Provides the JMX port
+ * for test connections and manages the lifecycle of the target JVM.
+ */
+public class TargetJvmProcess implements AutoCloseable {
+
+  private final Process process;
+  private final int jmxPort;
+
+  /**
+   * Starts the target JVM with JMX remote enabled on a random free port.
+   *
+   * @throws IOException if the process cannot be started
+   */
+  public TargetJvmProcess() throws IOException {
+    this.jmxPort = findFreePort();
+    String javaHome = System.getProperty("java.home");
+    String javaBin = javaHome + "/bin/java";
+    String classpath = System.getProperty("java.class.path");
+
+    ProcessBuilder pb =
+        new ProcessBuilder(
+            javaBin,
+            "-cp",
+            classpath,
+            "-Dcom.sun.management.jmxremote",
+            "-Dcom.sun.management.jmxremote.port=" + jmxPort,
+            "-Dcom.sun.management.jmxremote.authenticate=false",
+            "-Dcom.sun.management.jmxremote.ssl=false",
+            "-Dcom.sun.management.jmxremote.local.only=true",
+            "org.cyclopsgroup.jmxterm.e2e.TestTargetApp");
+    pb.redirectErrorStream(true);
+    this.process = pb.start();
+  }
+
+  /**
+   * Waits until the target JVM prints "READY" to stdout.
+   *
+   * @param timeout maximum time to wait
+   * @throws IOException if reading stdout fails
+   * @throws IllegalStateException if the timeout expires before "READY" is received
+   */
+  public void waitUntilReady(Duration timeout) throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+    CompletableFuture<Boolean> future =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                  if (line.contains("READY")) {
+                    return true;
+                  }
+                }
+                return false;
+              } catch (IOException e) {
+                return false;
+              }
+            });
+    try {
+      boolean ready = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      if (!ready) {
+        process.destroyForcibly();
+        throw new IllegalStateException("Target JVM exited without printing READY");
+      }
+    } catch (TimeoutException e) {
+      process.destroyForcibly();
+      throw new IllegalStateException(
+          "Target JVM did not become ready within " + timeout.toSeconds() + " seconds");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
+      throw new IllegalStateException("Interrupted while waiting for target JVM", e);
+    } catch (ExecutionException e) {
+      process.destroyForcibly();
+      throw new IllegalStateException("Error while waiting for target JVM", e.getCause());
+    }
+  }
+
+  /** @return the JMX remote port of the target JVM */
+  public int getJmxPort() {
+    return jmxPort;
+  }
+
+  /** @return the OS process ID of the target JVM */
+  public long getPid() {
+    return process.pid();
+  }
+
+  @Override
+  public void close() {
+    process.destroyForcibly();
+    try {
+      process.waitFor(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static int findFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/TestTargetApp.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/TestTargetApp.java
@@ -1,0 +1,78 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+
+/**
+ * Minimal JVM application that exposes JMX for end-to-end testing. Launched as a subprocess with
+ * JMX remote enabled. Prints "READY" to stdout when MBeans are registered. Blocks on stdin.read()
+ * — closes when parent closes stdin or sends input.
+ */
+public class TestTargetApp {
+
+  /** MBean interface exposed for testing. Embedded to avoid classpath issues in subprocess. */
+  public interface TestMBean {
+    String getName();
+
+    void setName(String name);
+
+    int getCount();
+
+    String echo(String input);
+
+    int add(int a, int b);
+
+    void reset();
+  }
+
+  /** Concrete implementation of {@link TestMBean}. */
+  public static class TestMBeanImpl implements TestMBean {
+    private String name = "default";
+    private int count = 0;
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public void setName(String name) {
+      this.name = name;
+      this.count++;
+    }
+
+    @Override
+    public int getCount() {
+      return count;
+    }
+
+    @Override
+    public String echo(String input) {
+      return "echo:" + input;
+    }
+
+    @Override
+    public int add(int a, int b) {
+      return a + b;
+    }
+
+    @Override
+    public void reset() {
+      name = "default";
+      count = 0;
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    mbs.registerMBean(
+        new StandardMBean(new TestMBeanImpl(), TestMBean.class),
+        new ObjectName("test:type=TestMBean"));
+    System.out.println("READY");
+    System.out.flush();
+    // Block until stdin is closed by the parent process
+    System.in.read();
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/AttributeReadWriteIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/AttributeReadWriteIT.java
@@ -22,25 +22,26 @@ class AttributeReadWriteIT {
 
   @BeforeEach
   void setUp() throws Exception {
+    resetMBeanState();
     resultWriter = new StringWriter();
     messageWriter = new StringWriter();
     cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
   }
 
   @AfterEach
-  void tearDown() {
+  void tearDown() throws Exception {
     cc.close();
-    // Reset the shared MBean state so tests are independent
-    try {
-      jmxServer
-          .getMBeanServer()
-          .invoke(
-              new javax.management.ObjectName("test:type=TestMBean"),
-              "reset",
-              null,
-              null);
-    } catch (Exception ignored) {
-    }
+    resetMBeanState();
+  }
+
+  private void resetMBeanState() throws Exception {
+    jmxServer
+        .getMBeanServer()
+        .invoke(
+            new javax.management.ObjectName("test:type=TestMBean"),
+            "reset",
+            null,
+            null);
   }
 
   @Test

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/AttributeReadWriteIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/AttributeReadWriteIT.java
@@ -1,0 +1,123 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for reading and writing MBean attributes via a real JMX connection. */
+class AttributeReadWriteIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+    // Reset the shared MBean state so tests are independent
+    try {
+      jmxServer
+          .getMBeanServer()
+          .invoke(
+              new javax.management.ObjectName("test:type=TestMBean"),
+              "reset",
+              null,
+              null);
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
+  void testGetStringAttribute() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("get Name"));
+    assertTrue(resultWriter.toString().contains("default"));
+  }
+
+  @Test
+  void testGetIntAttribute() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("get Count"));
+    assertTrue(resultWriter.toString().contains("0"));
+  }
+
+  @Test
+  void testGetAllAttributes() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("get *"));
+    String result = resultWriter.toString();
+    assertTrue(result.contains("Name"), "Expected output to contain 'Name', got: " + result);
+    assertTrue(result.contains("Count"), "Expected output to contain 'Count', got: " + result);
+  }
+
+  @Test
+  void testGetWithBeanOption() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("get -b test:type=TestMBean Name"));
+    assertTrue(resultWriter.toString().contains("default"));
+  }
+
+  @Test
+  void testSetAndGetAttribute() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("set -b test:type=TestMBean Name newValue"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("get -b test:type=TestMBean Name"));
+    assertTrue(
+        resultWriter.toString().contains("newValue"),
+        "Expected 'newValue' in output, got: " + resultWriter);
+  }
+
+  @Test
+  void testSetAndVerifyCount() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("set -b test:type=TestMBean Name changed"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("get -b test:type=TestMBean Count"));
+    assertTrue(
+        resultWriter.toString().contains("1"),
+        "Expected Count to be 1 after one set, got: " + resultWriter);
+  }
+
+  @Test
+  void testGetSimpleFormat() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("get -s -b test:type=TestMBean Name"));
+    String result = resultWriter.toString().trim();
+    assertTrue(
+        result.contains("default"),
+        "Expected simple format value 'default', got: " + result);
+    assertFalse(
+        result.contains("Name ="),
+        "Simple format should not contain 'Name =', got: " + result);
+  }
+
+  @Test
+  void testGetNonExistentAttribute() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    // GetCommand succeeds but produces no result output for unknown attributes
+    assertTrue(cc.execute("get -b test:type=TestMBean NonExistent"));
+    assertFalse(
+        resultWriter.toString().contains("NonExistent"),
+        "Expected no result for non-existent attribute, got: " + resultWriter);
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/CommandChainingIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/CommandChainingIT.java
@@ -22,21 +22,23 @@ class CommandChainingIT {
 
   @BeforeEach
   void setUp() throws Exception {
+    resetMBeanState();
     resultWriter = new StringWriter();
     messageWriter = new StringWriter();
     cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
   }
 
   @AfterEach
-  void tearDown() {
+  void tearDown() throws Exception {
     cc.close();
-    try {
-      jmxServer
-          .getMBeanServer()
-          .invoke(
-              new javax.management.ObjectName("test:type=TestMBean"), "reset", null, null);
-    } catch (Exception ignored) {
-    }
+    resetMBeanState();
+  }
+
+  private void resetMBeanState() throws Exception {
+    jmxServer
+        .getMBeanServer()
+        .invoke(
+            new javax.management.ObjectName("test:type=TestMBean"), "reset", null, null);
   }
 
   @Test

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/CommandChainingIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/CommandChainingIT.java
@@ -1,0 +1,89 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for command chaining, comments, and empty commands. */
+class CommandChainingIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+    try {
+      jmxServer
+          .getMBeanServer()
+          .invoke(
+              new javax.management.ObjectName("test:type=TestMBean"), "reset", null, null);
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
+  void testCommandChaining() {
+    assertTrue(
+        cc.execute(
+            "open " + jmxServer.getConnectionUrl() + " && domains && beans -d test"));
+    String result = resultWriter.toString();
+    assertTrue(result.contains("test"), "Expected 'test' domain in output, got: " + result);
+    assertTrue(
+        result.contains("JMImplementation"),
+        "Expected 'JMImplementation' domain in output, got: " + result);
+    assertTrue(
+        result.contains("test:type=TestMBean"),
+        "Expected 'test:type=TestMBean' in output, got: " + result);
+  }
+
+  @Test
+  void testCommentHandling() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("domains # this is a comment"));
+    String result = resultWriter.toString();
+    assertTrue(result.contains("test"), "Expected domains output, got: " + result);
+  }
+
+  @Test
+  void testFullLineComment() {
+    assertTrue(cc.execute("# this is a comment"));
+    assertEquals("", resultWriter.toString(), "Full-line comment should produce no output");
+  }
+
+  @Test
+  void testEscapedHash() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("set -b test:type=TestMBean Name value\\#with\\#hashes"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("get -b test:type=TestMBean Name"));
+    String result = resultWriter.toString();
+    assertTrue(
+        result.contains("value#with#hashes"),
+        "Expected value with unescaped hashes, got: " + result);
+  }
+
+  @Test
+  void testEmptyCommand() {
+    assertTrue(cc.execute(""), "Empty command should succeed");
+    assertEquals("", resultWriter.toString(), "Empty command should produce no output");
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/ConnectionLifecycleIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/ConnectionLifecycleIT.java
@@ -1,0 +1,88 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for JMX connection lifecycle: open, close, reconnect. */
+class ConnectionLifecycleIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+  }
+
+  @Test
+  void testOpenConnection() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("close"));
+  }
+
+  @Test
+  void testOpenDisplaysConnectionInfo() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("open"));
+    String result = resultWriter.toString();
+    assertTrue(
+        result.contains(jmxServer.getServiceUrl()),
+        "Expected service URL in output, got: " + result);
+  }
+
+  @Test
+  void testCloseAndReconnect() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("close"));
+    assertTrue(
+        cc.execute("open " + jmxServer.getConnectionUrl()),
+        "Reconnection after close should succeed");
+    // Verify the connection works by running a command
+    assertTrue(cc.execute("domains"));
+  }
+
+  @Test
+  void testOpenWhenAlreadyConnected() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertFalse(
+        cc.execute("open " + jmxServer.getConnectionUrl()),
+        "Opening a second connection without closing should fail");
+  }
+
+  @Test
+  void testCloseWithoutOpen() {
+    assertTrue(
+        cc.execute("close"),
+        "Closing without an open connection should succeed (no-op disconnect)");
+  }
+
+  @Test
+  void testOpenWithFullServiceUrl() {
+    assertTrue(cc.execute("open " + jmxServer.getServiceUrl()));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("open"));
+    String result = resultWriter.toString();
+    assertTrue(
+        result.contains(jmxServer.getServiceUrl()),
+        "Expected service URL in output, got: " + result);
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/DomainBeanNavigationIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/DomainBeanNavigationIT.java
@@ -1,0 +1,101 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for browsing domains, beans, and MBean info via a real JMX connection. */
+class DomainBeanNavigationIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+  }
+
+  @Test
+  void testListDomains() {
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("domains"));
+    String result = resultWriter.toString();
+    assertTrue(result.contains("test"), "Expected 'test' domain, got: " + result);
+    assertTrue(
+        result.contains("JMImplementation"),
+        "Expected 'JMImplementation' domain, got: " + result);
+  }
+
+  @Test
+  void testSelectDomain() {
+    assertTrue(cc.execute("domain test"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("domain"));
+    String result = resultWriter.toString();
+    assertTrue(result.contains("test"), "Expected current domain 'test', got: " + result);
+  }
+
+  @Test
+  void testListBeans() {
+    assertTrue(cc.execute("domain test"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("beans"));
+    String result = resultWriter.toString();
+    assertTrue(
+        result.contains("test:type=TestMBean"),
+        "Expected 'test:type=TestMBean' in beans output, got: " + result);
+  }
+
+  @Test
+  void testSelectBean() {
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("bean"));
+    String result = resultWriter.toString();
+    assertTrue(
+        result.contains("test:type=TestMBean"),
+        "Expected current bean 'test:type=TestMBean', got: " + result);
+  }
+
+  @Test
+  void testListBeansWithDomainOption() {
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("beans -d test"));
+    String result = resultWriter.toString();
+    assertTrue(
+        result.contains("test:type=TestMBean"),
+        "Expected 'test:type=TestMBean' in beans output, got: " + result);
+  }
+
+  @Test
+  void testInfoCommand() {
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("info"));
+    String result = resultWriter.toString();
+    // Verify attributes are listed
+    assertTrue(result.contains("Name"), "Expected attribute 'Name' in info, got: " + result);
+    assertTrue(result.contains("Count"), "Expected attribute 'Count' in info, got: " + result);
+    // Verify operations are listed
+    assertTrue(result.contains("echo"), "Expected operation 'echo' in info, got: " + result);
+    assertTrue(result.contains("add"), "Expected operation 'add' in info, got: " + result);
+    assertTrue(result.contains("reset"), "Expected operation 'reset' in info, got: " + result);
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/EmbeddedJmxServer.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/EmbeddedJmxServer.java
@@ -1,9 +1,10 @@
 package org.cyclopsgroup.jmxterm.integration;
 
-import java.net.ServerSocket;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+import java.rmi.server.ExportException;
 import java.rmi.server.UnicastRemoteObject;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
@@ -29,6 +30,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
 
+  private static final int MAX_PORT_RETRIES = 10;
+
   private MBeanServer mBeanServer;
   private JMXConnectorServer connectorServer;
   private Registry registry;
@@ -36,10 +39,8 @@ public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
-    // Find a free port
-    try (ServerSocket ss = new ServerSocket(0)) {
-      port = ss.getLocalPort();
-    }
+    // Create RMI registry with retry to avoid TOCTOU race on port selection
+    registry = createRegistryOnRandomPort();
 
     // Create a dedicated MBeanServer (not the platform one, to avoid side effects)
     mBeanServer = MBeanServerFactory.createMBeanServer("test-" + port);
@@ -49,15 +50,27 @@ public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
         new StandardMBean(new TestMBeanImpl(), TestMBean.class),
         new ObjectName("test:type=TestMBean"));
 
-    // Create RMI registry on the chosen port
-    registry = LocateRegistry.createRegistry(port);
-
     // Start JMX connector server
     JMXServiceURL url =
         new JMXServiceURL(
             "service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi");
     connectorServer = JMXConnectorServerFactory.newJMXConnectorServer(url, null, mBeanServer);
     connectorServer.start();
+  }
+
+  private Registry createRegistryOnRandomPort() throws Exception {
+    for (int attempt = 0; attempt < MAX_PORT_RETRIES; attempt++) {
+      int candidatePort = ThreadLocalRandom.current().nextInt(49152, 65536);
+      try {
+        Registry reg = LocateRegistry.createRegistry(candidatePort);
+        this.port = candidatePort;
+        return reg;
+      } catch (ExportException e) {
+        // Port already in use, retry with a different port
+      }
+    }
+    throw new IllegalStateException(
+        "Failed to create RMI registry after " + MAX_PORT_RETRIES + " attempts");
   }
 
   @Override

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/EmbeddedJmxServer.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/EmbeddedJmxServer.java
@@ -1,0 +1,95 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import java.net.ServerSocket;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.management.remote.JMXConnectorServer;
+import javax.management.remote.JMXConnectorServerFactory;
+import javax.management.remote.JMXServiceURL;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that starts an embedded JMX connector server for integration testing. The
+ * server listens on a random available port and registers a {@link TestMBeanImpl} under the {@code
+ * test:type=TestMBean} ObjectName.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @RegisterExtension
+ * static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+ * }</pre>
+ */
+public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
+
+  private MBeanServer mBeanServer;
+  private JMXConnectorServer connectorServer;
+  private Registry registry;
+  private int port;
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    // Find a free port
+    try (ServerSocket ss = new ServerSocket(0)) {
+      port = ss.getLocalPort();
+    }
+
+    // Create a dedicated MBeanServer (not the platform one, to avoid side effects)
+    mBeanServer = MBeanServerFactory.createMBeanServer("test-" + port);
+
+    // Register test MBean
+    mBeanServer.registerMBean(
+        new StandardMBean(new TestMBeanImpl(), TestMBean.class),
+        new ObjectName("test:type=TestMBean"));
+
+    // Create RMI registry on the chosen port
+    registry = LocateRegistry.createRegistry(port);
+
+    // Start JMX connector server
+    JMXServiceURL url =
+        new JMXServiceURL(
+            "service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi");
+    connectorServer = JMXConnectorServerFactory.newJMXConnectorServer(url, null, mBeanServer);
+    connectorServer.start();
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    if (connectorServer != null) {
+      connectorServer.stop();
+    }
+    if (registry != null) {
+      UnicastRemoteObject.unexportObject(registry, true);
+    }
+    if (mBeanServer != null) {
+      MBeanServerFactory.releaseMBeanServer(mBeanServer);
+    }
+  }
+
+  /** @return The port the JMX connector server is listening on */
+  public int getPort() {
+    return port;
+  }
+
+  /** @return A connection URL in {@code localhost:PORT} format suitable for the open command */
+  public String getConnectionUrl() {
+    return "localhost:" + port;
+  }
+
+  /** @return The full JMX service URL string */
+  public String getServiceUrl() {
+    return "service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi";
+  }
+
+  /** @return The underlying MBeanServer for direct manipulation in tests */
+  public MBeanServer getMBeanServer() {
+    return mBeanServer;
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/ErrorHandlingIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/ErrorHandlingIT.java
@@ -1,0 +1,77 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for error handling in various failure scenarios. */
+class ErrorHandlingIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+  }
+
+  @Test
+  void testGetWithoutConnection() {
+    assertFalse(
+        cc.execute("get Name"),
+        "Expected failure when getting attribute without a connection");
+  }
+
+  @Test
+  void testGetWithoutBean() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertFalse(
+        cc.execute("get Name"), "Expected failure when getting attribute without selecting a bean");
+  }
+
+  @Test
+  void testInvalidBeanName() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertFalse(
+        cc.execute("bean invalid:name:format:::"),
+        "Expected failure for malformed bean name");
+  }
+
+  @Test
+  void testConnectToBadPort() {
+    assertFalse(
+        cc.execute("open localhost:1"),
+        "Expected failure when connecting to an invalid port");
+  }
+
+  @Test
+  void testDomainWithoutConnection() {
+    assertFalse(
+        cc.execute("domains"), "Expected failure when listing domains without a connection");
+  }
+
+  @Test
+  void testSetReadOnlyAttribute() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertFalse(
+        cc.execute("set -b test:type=TestMBean Count 5"),
+        "Expected failure when setting read-only attribute Count");
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/OperationInvocationIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/OperationInvocationIT.java
@@ -1,0 +1,109 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for invoking MBean operations via a real JMX connection. */
+class OperationInvocationIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+    try {
+      jmxServer
+          .getMBeanServer()
+          .invoke(
+              new javax.management.ObjectName("test:type=TestMBean"),
+              "reset",
+              null,
+              null);
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
+  void testRunEchoOperation() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("run echo hello"));
+    assertTrue(
+        resultWriter.toString().contains("echo:hello"),
+        "Expected 'echo:hello' in output, got: " + resultWriter);
+  }
+
+  @Test
+  void testRunAddOperation() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("run add 3 5"));
+    assertTrue(
+        resultWriter.toString().contains("8"),
+        "Expected '8' in output, got: " + resultWriter);
+  }
+
+  @Test
+  void testRunResetOperation() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("set Name changed"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("get Name"));
+    assertTrue(
+        resultWriter.toString().contains("changed"),
+        "Expected 'changed' after set, got: " + resultWriter);
+
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("run reset"));
+    resultWriter.getBuffer().setLength(0);
+    assertTrue(cc.execute("get Name"));
+    assertTrue(
+        resultWriter.toString().contains("default"),
+        "Expected 'default' after reset, got: " + resultWriter);
+  }
+
+  @Test
+  void testRunWithBeanOption() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("run -b test:type=TestMBean echo world"));
+    assertTrue(
+        resultWriter.toString().contains("echo:world"),
+        "Expected 'echo:world' in output, got: " + resultWriter);
+  }
+
+  @Test
+  void testRunNonExistentOperation() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertFalse(cc.execute("run nonExistent"));
+  }
+
+  @Test
+  void testRunWithWrongParamCount() {
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertFalse(
+        cc.execute("run echo too many params"),
+        "Expected failure when invoking echo with wrong number of parameters");
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/OperationInvocationIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/OperationInvocationIT.java
@@ -22,24 +22,26 @@ class OperationInvocationIT {
 
   @BeforeEach
   void setUp() throws Exception {
+    resetMBeanState();
     resultWriter = new StringWriter();
     messageWriter = new StringWriter();
     cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
   }
 
   @AfterEach
-  void tearDown() {
+  void tearDown() throws Exception {
     cc.close();
-    try {
-      jmxServer
-          .getMBeanServer()
-          .invoke(
-              new javax.management.ObjectName("test:type=TestMBean"),
-              "reset",
-              null,
-              null);
-    } catch (Exception ignored) {
-    }
+    resetMBeanState();
+  }
+
+  private void resetMBeanState() throws Exception {
+    jmxServer
+        .getMBeanServer()
+        .invoke(
+            new javax.management.ObjectName("test:type=TestMBean"),
+            "reset",
+            null,
+            null);
   }
 
   @Test

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/TestMBean.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/TestMBean.java
@@ -1,0 +1,19 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+/**
+ * MBean interface for integration testing. Exposes readable/writable attributes and invocable
+ * operations with various parameter and return types.
+ */
+public interface TestMBean {
+  String getName();
+
+  void setName(String name);
+
+  int getCount();
+
+  String echo(String input);
+
+  int add(int a, int b);
+
+  void reset();
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/TestMBeanImpl.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/TestMBeanImpl.java
@@ -1,0 +1,39 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+/** Implementation of {@link TestMBean} for integration testing. */
+public class TestMBeanImpl implements TestMBean {
+  private String name = "default";
+  private int count = 0;
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
+    this.count++;
+  }
+
+  @Override
+  public int getCount() {
+    return count;
+  }
+
+  @Override
+  public String echo(String input) {
+    return "echo:" + input;
+  }
+
+  @Override
+  public int add(int a, int b) {
+    return a + b;
+  }
+
+  @Override
+  public void reset() {
+    name = "default";
+    count = 0;
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/VerboseLevelIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/VerboseLevelIT.java
@@ -1,0 +1,93 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.VerboseLevel;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for verbose level filtering of output and error messages. */
+class VerboseLevelIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+  }
+
+  @Test
+  void testBriefMessages() {
+    // Default level is BRIEF — messages should appear with '#' prefix
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    String messages = messageWriter.toString();
+    assertTrue(
+        messages.contains("#"),
+        "Expected '#' prefixed messages in BRIEF mode, got: " + messages);
+    assertTrue(
+        messages.contains("Connection to"),
+        "Expected connection message, got: " + messages);
+  }
+
+  @Test
+  void testSilentSuppressesMessages() {
+    cc.setVerboseLevel(VerboseLevel.SILENT);
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("get Name"));
+    String messages = messageWriter.toString();
+    assertTrue(messages.isEmpty(), "Expected no messages in SILENT mode, got: " + messages);
+  }
+
+  @Test
+  void testSilentStillShowsValues() {
+    cc.setVerboseLevel(VerboseLevel.SILENT);
+    assertTrue(cc.execute("open " + jmxServer.getConnectionUrl()));
+    assertTrue(cc.execute("bean test:type=TestMBean"));
+    assertTrue(cc.execute("get Name"));
+    assertTrue(
+        resultWriter.toString().contains("default"),
+        "Expected result value 'default' even in SILENT mode, got: " + resultWriter);
+  }
+
+  @Test
+  void testVerboseShowsStackTraces() {
+    cc.setVerboseLevel(VerboseLevel.VERBOSE);
+    // Execute a command that will fail (get attribute without connection)
+    assertFalse(cc.execute("get Name"));
+    String messages = messageWriter.toString();
+    assertTrue(
+        messages.contains("at "),
+        "Expected stack trace lines in VERBOSE mode, got: " + messages);
+  }
+
+  @Test
+  void testBriefShowsShortErrors() {
+    // Default level is BRIEF
+    assertFalse(cc.execute("get Name"));
+    String messages = messageWriter.toString();
+    assertTrue(
+        messages.contains("#"),
+        "Expected '#' prefixed error in BRIEF mode, got: " + messages);
+    assertFalse(
+        messages.contains("\tat "),
+        "Expected no full stack trace in BRIEF mode, got: " + messages);
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a two-tier automated test suite that goes beyond the existing unit tests (which mock `MBeanServerConnection`) to verify jmxterm against real JMX infrastructure.

---

## Tier 1 — Integration tests

**Location:** `src/test/java/org/cyclopsgroup/jmxterm/integration/`

Integration tests call `CommandCenter` directly in-process against a real embedded JMX server. They exercise the full command lifecycle — argument parsing → command dispatch → JMX protocol call → result formatting → output — without spawning a separate process.

### Infrastructure

- **`EmbeddedJmxServer`** — JUnit 5 extension that starts a `JMXConnectorServer` bound to a random `localhost` port, registers `test:type=TestMBean`, and tears down after each test class.
- **`TestMBean` / `TestMBeanImpl`** — test MBean exposing readable/writable attributes and an invocable operation.

### Tests

| Class | What it covers |
|---|---|
| `AttributeReadWriteIT` | `get` and `set` commands against real MBean attributes |
| `CommandChainingIT` | `open` → `domain` → `bean` → `get` chained command flow |
| `ConnectionLifecycleIT` | `open`, `close`, reconnect, and URL validation |
| `DomainBeanNavigationIT` | `domains`, `beans`, and `bean` navigation commands |
| `ErrorHandlingIT` | Error output and verbose level behaviour |
| `OperationInvocationIT` | `run` command invoking MBean operations |
| `VerboseLevelIT` | `option verbose` switching between silent / brief / verbose modes |

---

## Tier 2 — End-to-end tests

**Location:** `src/test/java/org/cyclopsgroup/jmxterm/e2e/`

E2E tests launch the fully packaged uber JAR as a separate OS process and communicate with a second JVM exposing a test MBean over JMX. They test behaviour that cannot be verified in-process: CLI argument parsing, non-interactive mode, file I/O, auto-connect, and process exit codes.

```
┌─────────────────────┐     JMX/RMI      ┌──────────────────────┐
│   jmxterm process   │ ◄──────────────► │  target JVM process  │
│  (uber JAR, -n mode)│  localhost:<port> │  (TestTargetApp)     │
│  stdin ← test sends │                  │  MBean: test:type=   │
│  stdout → test reads│                  │    TestMBean         │
└─────────────────────┘                  └──────────────────────┘
```

### Infrastructure

- **`JmxTermProcessHelper`** — wraps a `Process` running the uber JAR in non-interactive mode; provides `sendCommandAndClose()` and `readAllOutput()`.
- **`TargetJvmProcess`** — launches `TestTargetApp` in a separate JVM with JMX exposed on a random port; waits until the MBean is reachable before tests proceed.
- **`TestTargetApp`** — minimal standalone app that registers `test:type=TestMBean` and waits to be killed.

### Tests

| Class | What it covers |
|---|---|
| `CliArgumentsE2EIT` | `-l` auto-connect, `-v silent` mode, verbose output suppression |
| `ExitCodeE2EIT` | Exit code 0 on success, `-N` (line number) on failure with `-e`, quit exit code |
| `ScriptExecutionE2EIT` | `--input` file-based script execution |

---

## Build changes

Added `maven-failsafe-plugin` to run `*IT.java` files during `mvn verify`:

```bash
# Run all tests (unit + integration + E2E)
mvn verify

# Run a single integration test
mvn verify -Dit.test=AttributeReadWriteIT

# Run a single E2E test
mvn verify -Dit.test=ExitCodeE2EIT#testSuccessfulExecution
```

Tests run across **JDK 17, 21, and 25** in CI.

---

## Documentation

- [`docs/integration-tests.md`](docs/integration-tests.md) — architecture, infrastructure, and usage guide for Tier 1
- [`docs/e2e-tests.md`](docs/e2e-tests.md) — architecture, infrastructure, and usage guide for Tier 2