### PR TITLE
feat(build): migrate to Java 25 only

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,9 +4,9 @@
 
 JMXTerm is an interactive command-line JMX client. Users connect to JMX-enabled Java applications to browse MBeans, get/set attributes, and invoke operations.
 
-- **Java 17**, Maven build, no Maven wrapper (use system `mvn`)
+- **Java 25**, Maven build, no Maven wrapper (use system `mvn`)
 - **Entry point**: `org.cyclopsgroup.jmxterm.boot.CliMain`
-- **CI tests on**: JDK 17, 21, 25
+- **CI tests on**: JDK 25
 
 ## Build Commands
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17', '21', '25']
+        java: ['25']
     
     steps:
       - name: 📦 Checkout Code
@@ -52,17 +52,17 @@ jobs:
       - name: 📦 Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: 🚀 Set up JDK 17
+      - name: 🚀 Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
           server-id: github
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      # This publishes the "official" artifact to GitHub Packages - just Java 17 version
+      # This publishes the "official" artifact to GitHub Packages - just Java 25 version
       - name: 📦 Deploy to GitHub Packages
         run: mvn -B deploy --file pom.xml -DskipTests
         env:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,11 +1,11 @@
-# This workflow builds and tests the project across multiple JDKs (17, 21, 25),
-# while producing release artifacts (and Docker image) only once (on JDK 17)
+# This workflow builds and tests the project on JDK 25,
+# while producing release artifacts (and Docker image) once
 # to avoid duplicate artifacts and repeated security scanning.
 #
 # Matrix test job:
-#   - Runs 'mvn -B verify' on JDK 17, 21, 25
+#   - Runs 'mvn -B verify' on JDK 25
 # Build job:
-#   - Runs full package & security scanning on JDK 17 only
+#   - Runs full package & security scanning on JDK 25 only
 # Docker job:
 #   - Builds and (on non-PR events) pushes multi-arch image based on the packaged artifacts
 
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 25]
+        java: [25]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,7 +44,7 @@ jobs:
         run: mvn -B -q --no-transfer-progress verify
 
   build:
-    name: Package & Scan (JDK 17)
+    name: Package & Scan (JDK 25)
     permissions:
       contents: write  # for artifact upload
       security-events: write  # for trivy upload
@@ -53,10 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,11 +42,11 @@ jobs:
             echo "changes=true" >> $GITHUB_ENV
           fi
 
-      - name: 🚀 Set up JDK 17
+      - name: 🚀 Set up JDK 25
         if: env.changes == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <release>17</release>
+          <release>25</release>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Drops support for Java 17 and 21. All build, test, and release pipelines now target Java 25 exclusively.

## Changes

- **pom.xml** — compiler release 17 → 25
- **maven.yaml** — test matrix reduced to JDK 25 only, build job updated
- **create-release.yaml** — build matrix reduced to JDK 25 only, publish job updated
- **nightly-build.yml** — nightly builds use JDK 25
- **copilot-instructions.md** — updated Java version references
- **Dockerfile** — already uses `eclipse-temurin:25-jre-alpine` (no change needed)