### PR TITLE
feat(cmd): add JMXMP protocol support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,6 +55,14 @@ Arguments and options use annotations from `org.cyclopsgroup.jcli.annotation`:
 
 `Session` (abstract class) holds the JMX connection state plus the currently selected domain and bean. `SessionImpl` in `cc/` is the concrete implementation. Session is **not thread-safe** — `CommandCenter` synchronizes all calls. Commands receive the session via `setSession()` before each `execute()` call.
 
+Both RMI and JMXMP protocols are supported. URL formats:
+- `host:port` — RMI shorthand (default), expands to `service:jmx:rmi:///jndi/rmi://host:port/jmxrmi`
+- `jmxmp://host:port` — JMXMP shorthand, expands to `service:jmx:jmxmp://host:port`
+- `service:jmx:...` — full JMX service URL (any protocol)
+- `<PID>` — attaches to a local JVM process
+
+`JMXConnectorFactory` auto-discovers the JMXMP provider at runtime via the Java service loader (`META-INF/services`).
+
 ### IO Abstraction
 
 `CommandInput` and `CommandOutput` are abstract base classes with implementations for interactive console (JLine), files, streams, and writers. `VerboseCommandOutput` is a decorator that filters output based on `VerboseLevel` (SILENT, BRIEF, VERBOSE).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ $> quit
 
 | Command | Description |
 |---|---|
-| `open <host:port>` | Connect to a remote JMX endpoint |
+| `open <host:port>` | Connect to a remote JMX endpoint (RMI) |
+| `open jmxmp://<host:port>` | Connect to a remote JMX endpoint (JMXMP) |
 | `open <pid>` | Attach to a local JVM by process ID |
 | `domains` | List all MBean domains |
 | `beans` | List all MBeans (optionally filter by domain with `-d`) |
@@ -67,6 +68,17 @@ $> quit
 | `close` | Disconnect from the JMX endpoint |
 | `jvms` | List local Java processes |
 | `help` | Show all available commands |
+
+### JMXMP Connections
+
+To connect using the JMXMP protocol instead of the default RMI:
+
+```
+$> open jmxmp://localhost:9999
+#Connection to jmxmp://localhost:9999 is opened
+```
+
+Full service URLs are also supported: `open service:jmx:jmxmp://localhost:9999`
 
 ### Non-Interactive Mode
 
@@ -107,6 +119,7 @@ jmxsh
 
 - **Interactive REPL** with tab completion and command history (JLine)
 - **Remote & local connections** — connect via host:port, JMX URL, or local PID
+- **JMXMP protocol support** — connect via `jmxmp://host:port` in addition to the default RMI protocol
 - **Full MBean support** — browse domains, read/write attributes, invoke operations
 - **Command chaining** — run multiple commands in one line with `&&`
 - **Script mode** — automate JMX operations via files or piped input

--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,6 @@ Several dependencies are unused or barely used and can be replaced with JDK stan
 
 ## Build / POM
 
-- ~~🟠 **Switch uber JAR from `maven-assembly-plugin` to `maven-shade-plugin`**~~ ✅ Done — The shade plugin handles `META-INF/services` merging via resource transformers and supports class relocation.
 - 🟠 **Add `maven-enforcer-plugin` rules** — The plugin is in `pluginManagement` but has no active rules. Add: `requireMavenVersion` (≥ 3.8), `requireJavaVersion` (≥ 25), `banDuplicatePomDependencyVersions`, `dependencyConvergence`.
 - 🟡 **Add static analysis plugin** — No static analysis is currently configured. Consider SpotBugs (`spotbugs-maven-plugin`), Checkstyle (`maven-checkstyle-plugin`), or ErrorProne for compile-time bug detection.
 - 🟡 **Add `.editorconfig`** — Not present. Ensures consistent indentation, charset, and line endings across IDEs and editors.
@@ -69,7 +68,6 @@ Several dependencies are unused or barely used and can be replaced with JDK stan
 
 ## Testing
 
-- ~~🟡 **Evaluate migrating JMock → Mockito**~~ ✅ Done — Migrated to Mockito + AssertJ. All test classes now use `mock()`, `when()`, `verify()` and `assertThat()`.
 - 🟡 **Add test coverage reporting (JaCoCo)** — No coverage tool is configured. Add `jacoco-maven-plugin` to generate reports and optionally enforce minimum coverage thresholds.
 - 🟢 **Address existing TODO in `WatchCommand`** — Line 28: `TODO Consider the use case for CSV file backend generation`. Decide whether to implement or remove the comment.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -126,6 +126,10 @@ An interface (`org.cyclopsgroup.jmxterm.Connection`) implemented by `ConnectionI
 `JMXConnector` and provides access to the `MBeanServerConnection`, the connection URL, and the
 connector ID. Created when `Session.connect()` is called and destroyed on `Session.disconnect()`.
 
+Both RMI (`service:jmx:rmi://...`) and JMXMP (`service:jmx:jmxmp://...`) protocols are supported.
+`JMXConnectorFactory` auto-discovers the appropriate connector provider via the Java service loader
+mechanism — the JMXMP provider is bundled in the uber JAR.
+
 ### MBeanServerConnection
 
 The standard JMX interface (`javax.management.MBeanServerConnection`) obtained from the

--- a/docs/index.html
+++ b/docs/index.html
@@ -120,7 +120,8 @@ null
             </tr>
           </thead>
           <tbody>
-            <tr><td><code>open &lt;host:port&gt;</code></td><td>Connect to a remote JMX endpoint</td></tr>
+            <tr><td><code>open &lt;host:port&gt;</code></td><td>Connect to a remote JMX endpoint (RMI)</td></tr>
+            <tr><td><code>open jmxmp://&lt;host:port&gt;</code></td><td>Connect to a remote JMX endpoint (JMXMP)</td></tr>
             <tr><td><code>open &lt;pid&gt;</code></td><td>Attach to a local JVM by process ID</td></tr>
             <tr><td><code>domains</code></td><td>List all MBean domains</td></tr>
             <tr><td><code>beans</code></td><td>List all MBeans (filter by domain with <code>-d</code>)</td></tr>
@@ -151,7 +152,7 @@ null
         <div class="feature">
           <div class="feature-icon">🔌</div>
           <h3>Remote &amp; Local</h3>
-          <p>Connect via host:port, JMX URL, or local PID.</p>
+          <p>Connect via host:port (RMI), jmxmp:// (JMXMP), JMX URL, or local PID.</p>
         </div>
         <div class="feature">
           <div class="feature-icon">📦</div>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
     <jline.version>4.0.9</jline.version>
 
 
+    <jmxremote-optional.version>5.0</jmxremote-optional.version>
+
     <!-- Test dependencies -->
     <mockito.version>5.18.0</mockito.version>
     <assertj.version>3.27.3</assertj.version>
@@ -101,6 +103,11 @@
       <version>${slf4j.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.main.external</groupId>
+      <artifactId>jmxremote_optional-repackaged</artifactId>
+      <version>${jmxremote-optional.version}</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -129,6 +136,7 @@
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
+
   </repositories>
 
   <build>

--- a/src/main/java/org/cyclopsgroup/jmxterm/SyntaxUtils.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/SyntaxUtils.java
@@ -25,6 +25,7 @@ public final class SyntaxUtils {
   public static final PrintStream NULL_PRINT_STREAM = new PrintStream(OutputStream.nullOutputStream(), true);
 
   private static final Pattern PATTERN_HOST_PORT = Pattern.compile("^(\\w|\\.|\\-)+\\:\\d+$");
+  private static final Pattern PATTERN_JMXMP_URL = Pattern.compile("^jmxmp://(\\S+)$");
 
   private static final Map<String, Class<?>> PRIMITIVE_TYPES = Map.ofEntries(
       Map.entry("boolean", boolean.class),
@@ -59,6 +60,8 @@ public final class SyntaxUtils {
       }
       return new JMXServiceURL(p.toUrl());
 
+    } else if (PATTERN_JMXMP_URL.matcher(url).find()) {
+      return new JMXServiceURL("service:jmx:" + url);
     } else if (PATTERN_HOST_PORT.matcher(url).find()) {
       return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + url + "/jmxrmi");
     } else {

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
@@ -168,7 +168,7 @@ public class CliMainOptions {
   @Option(
       name = "l",
       longName = "url",
-      description = "Location of MBean service. It can be <host>:<port> or full service URL.")
+      description = "Location of MBean service. It can be <host>:<port>, jmxmp://<host>:<port>, or full service URL.")
   public final void setUrl(String url) {
     Objects.requireNonNull(url, "URL can't be NULL");
     this.url = url;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
@@ -24,8 +24,11 @@ import org.cyclopsgroup.jmxterm.SyntaxUtils;
     note =
         """
         Without argument this command display current connection. \
-        URL can be a <PID>, <hostname>:<port> or full qualified JMX service URL. For example
+        URL can be a <PID>, <hostname>:<port> or full qualified JMX service URL. \
+        For JMXMP connections, use jmxmp://<hostname>:<port>. For example
          open localhost:9991,
+         open jmxmp://localhost:9991,
+         open service:jmx:jmxmp://localhost:9991,
          open jmx:service:...""")
 public class OpenCommand extends Command {
   private String password;
@@ -86,7 +89,7 @@ public class OpenCommand extends Command {
   }
 
   /** @param url URL of MBean service to open */
-  @Argument(displayName = "url", description = "URL, <host>:<port>, or a PID to connect to")
+  @Argument(displayName = "url", description = "URL, <host>:<port>, jmxmp://<host>:<port>, or a PID to connect to")
   public final void setUrl(String url) {
     this.url = url;
   }

--- a/src/test/java/org/cyclopsgroup/jmxterm/SyntaxUtilsTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/SyntaxUtilsTest.java
@@ -30,6 +30,39 @@ class SyntaxUtilsTest {
         .isEqualTo("/jndi/rmi://xyz-host.cyclopsgroup.org:12345/jmxrmi");
   }
 
+  @Test
+  void getUrlWithJmxmpShorthand() throws Exception {
+    assertThat(SyntaxUtils.getUrl("jmxmp://localhost:9999", null))
+        .satisfies(
+            url -> {
+              assertThat(url.getProtocol()).isEqualTo("jmxmp");
+              assertThat(url.getHost()).isEqualTo("localhost");
+              assertThat(url.getPort()).isEqualTo(9999);
+            });
+  }
+
+  @Test
+  void getUrlWithJmxmpShorthandDottedHost() throws Exception {
+    assertThat(SyntaxUtils.getUrl("jmxmp://my-host.example.com:5555", null))
+        .satisfies(
+            url -> {
+              assertThat(url.getProtocol()).isEqualTo("jmxmp");
+              assertThat(url.getHost()).isEqualTo("my-host.example.com");
+              assertThat(url.getPort()).isEqualTo(5555);
+            });
+  }
+
+  @Test
+  void getUrlWithFullJmxmpServiceUrl() throws Exception {
+    assertThat(SyntaxUtils.getUrl("service:jmx:jmxmp://localhost:9999", null))
+        .satisfies(
+            url -> {
+              assertThat(url.getProtocol()).isEqualTo("jmxmp");
+              assertThat(url.getHost()).isEqualTo("localhost");
+              assertThat(url.getPort()).isEqualTo(9999);
+            });
+  }
+
   /** Verify string expression of type is correctly parsed */
   @Test
   void parseNormally() {

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/JmxmpConnectionE2EIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/JmxmpConnectionE2EIT.java
@@ -1,0 +1,82 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests that launch jmxterm as a separate OS process, connect to a JMXMP target JVM, and
+ * verify command output.
+ */
+class JmxmpConnectionE2EIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static TargetJmxmpProcess targetJvm;
+
+  @BeforeAll
+  static void startTargetJvm() throws Exception {
+    targetJvm = new TargetJmxmpProcess();
+    targetJvm.waitUntilReady(TIMEOUT);
+  }
+
+  @AfterAll
+  static void stopTargetJvm() {
+    if (targetJvm != null) {
+      targetJvm.close();
+    }
+  }
+
+  @Test
+  void testOpenWithJmxmpShorthand() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open jmxmp://localhost:" + targetJvm.getJmxmpPort(), "domains", "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertThat(output)
+          .as("Expected 'JMImplementation' domain in output: " + output)
+          .contains("JMImplementation");
+    }
+  }
+
+  @Test
+  void testOpenWithFullJmxmpServiceUrl() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open service:jmx:jmxmp://localhost:" + targetJvm.getJmxmpPort(), "domains", "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertThat(output)
+          .as("Expected 'JMImplementation' domain in output: " + output)
+          .contains("JMImplementation");
+    }
+  }
+
+  @Test
+  void testGetAttributeOverJmxmp() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open jmxmp://localhost:" + targetJvm.getJmxmpPort(),
+          "bean test:type=TestMBean",
+          "run reset",
+          "get Name",
+          "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertThat(output).as("Expected 'default' in output: " + output).contains("default");
+    }
+  }
+
+  @Test
+  void testRunOperationOverJmxmp() throws Exception {
+    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+      jmxterm.sendCommandAndClose(
+          "open jmxmp://localhost:" + targetJvm.getJmxmpPort(),
+          "bean test:type=TestMBean",
+          "run echo world",
+          "quit");
+      String output = jmxterm.readAllOutput(TIMEOUT);
+      assertThat(output).as("Expected 'echo:world' in output: " + output).contains("echo:world");
+    }
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/TargetJmxmpProcess.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/TargetJmxmpProcess.java
@@ -1,0 +1,131 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Launches {@link TestTargetJmxmpApp} as a subprocess with a JMXMP connector server. Provides the
+ * JMXMP port for test connections and manages the lifecycle of the target JVM.
+ */
+public class TargetJmxmpProcess implements AutoCloseable {
+
+  private static final int MAX_PORT_RETRIES = 10;
+
+  private final Process process;
+  private final int jmxmpPort;
+  private volatile boolean ready;
+
+  /**
+   * Starts the target JVM with a JMXMP connector on a random port. Retries with a different port if
+   * the process fails to become ready.
+   *
+   * @throws IOException if the process cannot be started after all retries
+   */
+  public TargetJmxmpProcess() throws IOException {
+    int port = 0;
+    Process started = null;
+    for (int attempt = 0; attempt < MAX_PORT_RETRIES; attempt++) {
+      port = ThreadLocalRandom.current().nextInt(49152, 65536);
+      started = startProcess(port);
+      try {
+        waitUntilReady(started, Duration.ofSeconds(10));
+        break;
+      } catch (IllegalStateException e) {
+        started.destroyForcibly();
+        started = null;
+        if (attempt == MAX_PORT_RETRIES - 1) {
+          throw new IOException(
+              "Failed to start JMXMP target JVM after " + MAX_PORT_RETRIES + " attempts", e);
+        }
+      }
+    }
+    this.jmxmpPort = port;
+    this.process = started;
+    this.ready = true;
+  }
+
+  private static Process startProcess(int port) throws IOException {
+    String javaHome = System.getProperty("java.home");
+    String javaBin = javaHome + "/bin/java";
+    String classpath = System.getProperty("java.class.path");
+
+    ProcessBuilder pb =
+        new ProcessBuilder(
+            javaBin,
+            "-cp",
+            classpath,
+            "org.cyclopsgroup.jmxterm.e2e.TestTargetJmxmpApp",
+            String.valueOf(port));
+    pb.redirectErrorStream(true);
+    return pb.start();
+  }
+
+  /**
+   * Waits until the target JVM prints "READY" to stdout.
+   *
+   * @param timeout maximum time to wait
+   * @throws IllegalStateException if the timeout expires before "READY" is received
+   */
+  public void waitUntilReady(Duration timeout) {
+    if (ready) {
+      return;
+    }
+    waitUntilReady(process, timeout);
+    ready = true;
+  }
+
+  private static void waitUntilReady(Process proc, Duration timeout) {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+    CompletableFuture<Boolean> future =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                  if (line.contains("READY")) {
+                    return true;
+                  }
+                }
+                return false;
+              } catch (IOException e) {
+                return false;
+              }
+            });
+    try {
+      boolean ready = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      if (!ready) {
+        throw new IllegalStateException("JMXMP target JVM exited without printing READY");
+      }
+    } catch (TimeoutException e) {
+      throw new IllegalStateException(
+          "JMXMP target JVM did not become ready within " + timeout.toSeconds() + " seconds");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for JMXMP target JVM", e);
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("Error while waiting for JMXMP target JVM", e.getCause());
+    }
+  }
+
+  /** @return the JMXMP port of the target JVM */
+  public int getJmxmpPort() {
+    return jmxmpPort;
+  }
+
+  @Override
+  public void close() {
+    process.destroyForcibly();
+    try {
+      process.waitFor(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/e2e/TestTargetJmxmpApp.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/e2e/TestTargetJmxmpApp.java
@@ -1,0 +1,89 @@
+package org.cyclopsgroup.jmxterm.e2e;
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.management.remote.JMXConnectorServer;
+import javax.management.remote.JMXConnectorServerFactory;
+import javax.management.remote.JMXServiceURL;
+
+/**
+ * Minimal JVM application that exposes JMX over JMXMP for end-to-end testing. Unlike {@link
+ * TestTargetApp} which relies on JVM flags for RMI, this app programmatically starts a JMXMP
+ * connector server. Prints "READY &lt;port&gt;" to stdout. Blocks on stdin.read().
+ *
+ * <p>Usage: {@code java -cp <classpath> org.cyclopsgroup.jmxterm.e2e.TestTargetJmxmpApp <port>}
+ */
+public class TestTargetJmxmpApp {
+
+  /** MBean interface exposed for testing. */
+  public interface TestMBean {
+    String getName();
+
+    void setName(String name);
+
+    int getCount();
+
+    String echo(String input);
+
+    void reset();
+  }
+
+  /** Concrete implementation of {@link TestMBean}. */
+  public static class TestMBeanImpl implements TestMBean {
+    private String name = "default";
+    private int count = 0;
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public void setName(String name) {
+      this.name = name;
+      this.count++;
+    }
+
+    @Override
+    public int getCount() {
+      return count;
+    }
+
+    @Override
+    public String echo(String input) {
+      return "echo:" + input;
+    }
+
+    @Override
+    public void reset() {
+      name = "default";
+      count = 0;
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 1) {
+      System.err.println("Usage: TestTargetJmxmpApp <port>");
+      System.exit(1);
+    }
+    int port = Integer.parseInt(args[0]);
+
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    mbs.registerMBean(
+        new StandardMBean(new TestMBeanImpl(), TestMBean.class),
+        new ObjectName("test:type=TestMBean"));
+
+    JMXServiceURL url = new JMXServiceURL("service:jmx:jmxmp://localhost:" + port);
+    JMXConnectorServer connectorServer =
+        JMXConnectorServerFactory.newJMXConnectorServer(url, null, mbs);
+    connectorServer.start();
+
+    System.out.println("READY " + port);
+    System.out.flush();
+    // Block until stdin is closed by the parent process
+    System.in.read();
+    connectorServer.stop();
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/EmbeddedJmxmpServer.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/EmbeddedJmxmpServer.java
@@ -1,0 +1,89 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import java.util.concurrent.ThreadLocalRandom;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.management.remote.JMXConnectorServer;
+import javax.management.remote.JMXConnectorServerFactory;
+import javax.management.remote.JMXServiceURL;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that starts an embedded JMXMP connector server for integration testing. Unlike
+ * {@link EmbeddedJmxServer} (RMI), JMXMP does not require an RMI registry — it listens directly on
+ * a TCP port.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @RegisterExtension
+ * static EmbeddedJmxmpServer jmxmpServer = new EmbeddedJmxmpServer();
+ * }</pre>
+ */
+public class EmbeddedJmxmpServer implements BeforeAllCallback, AfterAllCallback {
+
+  private static final int MAX_PORT_RETRIES = 10;
+
+  private MBeanServer mBeanServer;
+  private JMXConnectorServer connectorServer;
+  private int port;
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    mBeanServer = MBeanServerFactory.createMBeanServer("test-jmxmp-" + hashCode());
+
+    mBeanServer.registerMBean(
+        new StandardMBean(new TestMBeanImpl(), TestMBean.class),
+        new ObjectName("test:type=TestMBean"));
+
+    // Try random ports until one succeeds (JMXMP binds directly, no RMI registry)
+    for (int attempt = 0; attempt < MAX_PORT_RETRIES; attempt++) {
+      int candidatePort = ThreadLocalRandom.current().nextInt(49152, 65536);
+      try {
+        JMXServiceURL url = new JMXServiceURL("service:jmx:jmxmp://localhost:" + candidatePort);
+        connectorServer = JMXConnectorServerFactory.newJMXConnectorServer(url, null, mBeanServer);
+        connectorServer.start();
+        this.port = candidatePort;
+        return;
+      } catch (Exception e) {
+        // Port already in use or bind failure, retry with a different port
+      }
+    }
+    throw new IllegalStateException(
+        "Failed to start JMXMP connector server after " + MAX_PORT_RETRIES + " attempts");
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    if (connectorServer != null) {
+      connectorServer.stop();
+    }
+    if (mBeanServer != null) {
+      MBeanServerFactory.releaseMBeanServer(mBeanServer);
+    }
+  }
+
+  /** @return The port the JMXMP connector server is listening on */
+  public int getPort() {
+    return port;
+  }
+
+  /** @return A connection URL in {@code jmxmp://localhost:PORT} shorthand format */
+  public String getConnectionUrl() {
+    return "jmxmp://localhost:" + port;
+  }
+
+  /** @return The full JMX service URL string */
+  public String getServiceUrl() {
+    return "service:jmx:jmxmp://localhost:" + port;
+  }
+
+  /** @return The underlying MBeanServer for direct manipulation in tests */
+  public MBeanServer getMBeanServer() {
+    return mBeanServer;
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/integration/JmxmpConnectionIT.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/integration/JmxmpConnectionIT.java
@@ -1,0 +1,79 @@
+package org.cyclopsgroup.jmxterm.integration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.StringWriter;
+import org.cyclopsgroup.jmxterm.cc.CommandCenter;
+import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Integration tests for JMX connections over the JMXMP protocol. */
+class JmxmpConnectionIT {
+
+  @RegisterExtension static EmbeddedJmxmpServer jmxmpServer = new EmbeddedJmxmpServer();
+
+  private CommandCenter cc;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+  }
+
+  @Test
+  void testOpenWithJmxmpShorthand() {
+    assertThat(cc.execute("open " + jmxmpServer.getConnectionUrl())).isTrue();
+    assertThat(cc.execute("close")).isTrue();
+  }
+
+  @Test
+  void testOpenWithFullJmxmpServiceUrl() {
+    assertThat(cc.execute("open " + jmxmpServer.getServiceUrl())).isTrue();
+    resultWriter.getBuffer().setLength(0);
+    assertThat(cc.execute("open")).isTrue();
+    String result = resultWriter.toString();
+    assertThat(result)
+        .as("Expected JMXMP service URL in output, got: " + result)
+        .contains(jmxmpServer.getServiceUrl());
+  }
+
+  @Test
+  void testListDomainsOverJmxmp() {
+    assertThat(cc.execute("open " + jmxmpServer.getConnectionUrl())).isTrue();
+    resultWriter.getBuffer().setLength(0);
+    assertThat(cc.execute("domains")).isTrue();
+    String result = resultWriter.toString();
+    assertThat(result).contains("test");
+  }
+
+  @Test
+  void testGetAttributeOverJmxmp() {
+    assertThat(cc.execute("open " + jmxmpServer.getConnectionUrl())).isTrue();
+    assertThat(cc.execute("bean test:type=TestMBean")).isTrue();
+    resultWriter.getBuffer().setLength(0);
+    assertThat(cc.execute("get Name")).isTrue();
+    String result = resultWriter.toString();
+    assertThat(result).contains("default");
+  }
+
+  @Test
+  void testCloseAndReconnectOverJmxmp() {
+    assertThat(cc.execute("open " + jmxmpServer.getConnectionUrl())).isTrue();
+    assertThat(cc.execute("close")).isTrue();
+    assertThat(cc.execute("open " + jmxmpServer.getConnectionUrl()))
+        .as("Reconnection after close should succeed")
+        .isTrue();
+    assertThat(cc.execute("domains")).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

Add support for connecting to JMX endpoints using the JMXMP protocol (JMX Messaging Protocol) in addition to the default RMI protocol.

## Changes

### Core
- **pom.xml**: Add `fish.payara.server.core.packager:jmxremote_optional-repackaged:6.27.0` dependency and Payara Maven repository
- **SyntaxUtils**: Add `jmxmp://host:port` shorthand URL pattern detection, expanding to `service:jmx:jmxmp://host:port`
- **OpenCommand**: Update `@Cli` help note and argument description to document JMXMP URLs
- **CliMainOptions**: Update `-l` flag description to mention JMXMP

### Tests
- **SyntaxUtilsTest**: Unit tests for JMXMP shorthand and full URL parsing
- **EmbeddedJmxmpServer**: JUnit 5 extension for embedded JMXMP connector server
- **JmxmpConnectionIT**: Integration tests for open/close/reconnect/attribute access over JMXMP
- **TestTargetJmxmpApp + TargetJmxmpProcess**: JMXMP target app and subprocess launcher
- **JmxmpConnectionE2EIT**: E2E tests verifying full jmxterm→JMXMP target flow

### Documentation
- **README.md**: JMXMP section, updated commands table, and features list
- **docs/index.html**: JMXMP in commands table and features card
- **docs/dev/architecture.md**: Connection section mentions JMXMP
- **.github/copilot-instructions.md**: URL format documentation for JMXMP

### Cleanup
- **TODO.md**: Removed 2 completed items (shade plugin migration, JMock→Mockito migration)

## Usage

```
$> open jmxmp://localhost:9999
#Connection to jmxmp://localhost:9999 is opened
```

Full service URLs also work: `open service:jmx:jmxmp://localhost:9999`

## How it works

The JMXMP connector provider JAR registers itself via `META-INF/services/javax.management.remote.JMXConnectorProvider`. The shade plugin's `ServicesResourceTransformer` merges this into the uber JAR. `JMXConnectorFactory.connect()` auto-discovers it at runtime — no changes needed to SessionImpl or ConnectionImpl.