### PR TITLE
chore(ci): remove archived kenji-miyake/setup-git-cliff action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,6 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Install git-cliff
-        uses: kenji-miyake/setup-git-cliff@e227e69cd63e3c35782fdbcfa076a521ad6e19e0 # v2
-        with:
-          version: 'latest'
-
       - name: Configure Git user
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
The `kenji-miyake/setup-git-cliff` repository was [archived on April 7, 2025](https://github.com/kenji-miyake/setup-git-cliff). This PR removes the "Install git-cliff" step from the release workflow.

**Why removal instead of replacement?**

The step installed the `git-cliff` binary into the runner's PATH, but no workflow step uses it directly. The only git-cliff consumer is `orhun/git-cliff-action` (step "Generate release notes"), which is Docker-based and bundles its own binary — making the setup step redundant.