### PR TITLE
feat(ci): simplify release workflow to single bump-type input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,14 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      releaseVersion:
-        description: 'Release version (e.g. 1.1.0)'
+      bump:
+        description: 'Version bump type'
         required: true
-      developmentVersion:
-        description: 'Next development version (e.g. 1.2.0-SNAPSHOT, leave blank to auto-increment)'
-        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: release
@@ -32,19 +34,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check tag does not already exist
-        run: |
-          if git rev-parse "v${{ inputs.releaseVersion }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ inputs.releaseVersion }} already exists"
-            exit 1
-          fi
-
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '25'
           distribution: temurin
           cache: maven
+
+      - name: Compute versions
+        run: |
+          current=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          if [[ ! "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-SNAPSHOT$ ]]; then
+            echo "::error::Expected semantic SNAPSHOT version (X.Y.Z-SNAPSHOT), got: $current"
+            exit 1
+          fi
+
+          major=${BASH_REMATCH[1]}
+          minor=${BASH_REMATCH[2]}
+          patch=${BASH_REMATCH[3]}
+          release="${major}.${minor}.${patch}"
+
+          case "${{ inputs.bump }}" in
+            patch) next="${major}.${minor}.$((patch + 1))-SNAPSHOT" ;;
+            minor) next="${major}.$((minor + 1)).0-SNAPSHOT" ;;
+            major) next="$((major + 1)).0.0-SNAPSHOT" ;;
+          esac
+
+          echo "RELEASE_VERSION=$release" >> "$GITHUB_ENV"
+          echo "DEVELOPMENT_VERSION=$next" >> "$GITHUB_ENV"
+          echo "Release: $release → Next: $next"
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "v${{ env.RELEASE_VERSION }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ env.RELEASE_VERSION }} already exists"
+            exit 1
+          fi
 
       - name: Configure Git user
         run: |
@@ -54,12 +79,12 @@ jobs:
       - name: Prepare release
         run: >
           mvn -B release:prepare
-          -DreleaseVersion=${{ inputs.releaseVersion }}
-          ${{ inputs.developmentVersion && format('-DdevelopmentVersion={0}', inputs.developmentVersion) || '' }}
+          -DreleaseVersion=${{ env.RELEASE_VERSION }}
+          -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }}
           -DpushChanges=false
 
       - name: Checkout release tag
-        run: git checkout v${{ inputs.releaseVersion }}
+        run: git checkout v${{ env.RELEASE_VERSION }}
 
       - name: Build artifacts
         run: mvn -B -q --no-transfer-progress clean package
@@ -71,7 +96,7 @@ jobs:
           mkdir -p "$pkg_dir/DEBIAN"
           cat > "$pkg_dir/DEBIAN/control" <<EOF
           Package: jmxsh
-          Version: ${{ inputs.releaseVersion }}
+          Version: ${{ env.RELEASE_VERSION }}
           Section: misc
           Priority: optional
           Architecture: all
@@ -81,7 +106,7 @@ jobs:
           EOF
 
           mkdir -p "$pkg_dir/usr/share/jmxsh"
-          cp "target/jmxsh-${{ inputs.releaseVersion }}-uber.jar" "$pkg_dir/usr/share/jmxsh/jmxsh-uber.jar"
+          cp "target/jmxsh-${{ env.RELEASE_VERSION }}-uber.jar" "$pkg_dir/usr/share/jmxsh/jmxsh-uber.jar"
 
           mkdir -p "$pkg_dir/usr/bin"
           cat > "$pkg_dir/usr/bin/jmxsh" <<'LAUNCHER'
@@ -90,7 +115,7 @@ jobs:
           LAUNCHER
           chmod 755 "$pkg_dir/usr/bin/jmxsh"
 
-          dpkg-deb --build "$pkg_dir" "target/jmxsh-${{ inputs.releaseVersion }}.deb"
+          dpkg-deb --build "$pkg_dir" "target/jmxsh-${{ env.RELEASE_VERSION }}.deb"
 
       - name: Build RPM package
         run: |
@@ -99,11 +124,11 @@ jobs:
           rpmbuild_dir="$(mktemp -d)"
           mkdir -p "$rpmbuild_dir"/{SPECS,SOURCES,BUILD,RPMS,SRPMS}
 
-          cp "target/jmxsh-${{ inputs.releaseVersion }}-uber.jar" "$rpmbuild_dir/SOURCES/"
+          cp "target/jmxsh-${{ env.RELEASE_VERSION }}-uber.jar" "$rpmbuild_dir/SOURCES/"
 
           cat > "$rpmbuild_dir/SPECS/jmxsh.spec" <<'SPEC'
           Name:           jmxsh
-          Version:        ${{ inputs.releaseVersion }}
+          Version:        ${{ env.RELEASE_VERSION }}
           Release:        1
           Summary:        Interactive command-line JMX client
           License:        Apache-2.0
@@ -115,7 +140,7 @@ jobs:
 
           %install
           install -d -m 755 %{buildroot}/usr/share/jmxsh
-          install -m 644 %{_sourcedir}/jmxsh-${{ inputs.releaseVersion }}-uber.jar %{buildroot}/usr/share/jmxsh/jmxsh-uber.jar
+          install -m 644 %{_sourcedir}/jmxsh-${{ env.RELEASE_VERSION }}-uber.jar %{buildroot}/usr/share/jmxsh/jmxsh-uber.jar
           install -d -m 755 %{buildroot}/usr/bin
           cat > %{buildroot}/usr/bin/jmxsh <<'LAUNCHER'
           #!/bin/sh -e
@@ -140,16 +165,16 @@ jobs:
         run: |
           git checkout master
           git push origin master
-          git push origin v${{ inputs.releaseVersion }}
+          git push origin v${{ env.RELEASE_VERSION }}
 
       - name: Create GitHub release
         run: >
-          gh release create v${{ inputs.releaseVersion }}
-          target/jmxsh-${{ inputs.releaseVersion }}*.jar
-          target/jmxsh-${{ inputs.releaseVersion }}.deb
+          gh release create v${{ env.RELEASE_VERSION }}
+          target/jmxsh-${{ env.RELEASE_VERSION }}*.jar
+          target/jmxsh-${{ env.RELEASE_VERSION }}.deb
           target/jmxsh-*.rpm
           -F git-cliff/CHANGELOG.md
-          --title "Release v${{ inputs.releaseVersion }}"
+          --title "Release v${{ env.RELEASE_VERSION }}"
           --verify-tag
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Check tag does not already exist
         run: |
-          if git rev-parse "v${{ env.RELEASE_VERSION }}" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/v${{ env.RELEASE_VERSION }}"; then
             echo "::error::Tag v${{ env.RELEASE_VERSION }} already exists"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
             patch) next="${major}.${minor}.$((patch + 1))-SNAPSHOT" ;;
             minor) next="${major}.$((minor + 1)).0-SNAPSHOT" ;;
             major) next="$((major + 1)).0.0-SNAPSHOT" ;;
+            *)
+              echo "::error::Unsupported version bump type: ${{ inputs.bump }}"
+              exit 1
+              ;;
           esac
 
           echo "RELEASE_VERSION=$release" >> "$GITHUB_ENV"


### PR DESCRIPTION
Replace the two manual inputs (`releaseVersion`, `developmentVersion`) with a single **bump** choice (`patch`, `minor`, `major`).

## How it works

The release version is derived from the pom.xml SNAPSHOT version, and the bump type determines the next development version:

| pom.xml version | Bump type | Release | Next development |
|---|---|---|---|
| `1.1.0-SNAPSHOT` | `patch` | `1.1.0` | `1.1.1-SNAPSHOT` |
| `1.1.0-SNAPSHOT` | `minor` | `1.1.0` | `1.2.0-SNAPSHOT` |
| `1.1.0-SNAPSHOT` | `major` | `1.1.0` | `2.0.0-SNAPSHOT` |

## Changes

- Replaced two inputs with a single `type: choice` input
- Added a "Compute versions" step that reads the project version via `mvn help:evaluate`, validates the `X.Y.Z-SNAPSHOT` format, and exports `RELEASE_VERSION` / `DEVELOPMENT_VERSION` to `GITHUB_ENV`
- All downstream steps now reference `env.RELEASE_VERSION` instead of `inputs.releaseVersion`
- Moved JDK setup before version computation (needed for `mvn` command)