### PR TITLE
fix(ci): install git-cliff binary before mvn release:prepare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,15 @@ jobs:
           distribution: temurin
           cache: maven
 
+      - name: Install git-cliff
+        run: |
+          gh release download --repo orhun/git-cliff --pattern 'git-cliff-*-x86_64-unknown-linux-gnu.tar.gz'
+          tar xzf git-cliff-*-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 --wildcards '*/git-cliff'
+          sudo mv git-cliff /usr/local/bin/
+          git cliff --version
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Compute versions
         run: |
           current=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)


### PR DESCRIPTION
## Problem

The release workflow fails with `git: 'cliff' is not a git command` during `mvn release:prepare`.

The `exec:exec` preparation goal runs `scripts/generate-changelog.sh`, which calls `git cliff`. PR #22 incorrectly removed the `kenji-miyake/setup-git-cliff` step as redundant — it was actually needed because this script runs **before** the `orhun/git-cliff-action` step.

## Fix

Replace the archived action with a direct binary download from the [git-cliff GitHub releases](https://github.com/orhun/git-cliff/releases). No dependency on any third-party action.

## Separate issue

The `git push origin master` step also fails due to branch protection rules requiring PRs — this is a pre-existing design issue not addressed here.