### PR TITLE
fix(ci): use PAT to bypass ruleset during release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5


### PR DESCRIPTION
The `GITHUB_TOKEN` cannot bypass repository rulesets. The release workflow's `git push origin master` fails with:

```
GH013: Repository rule violations found for refs/heads/master.
- 2 of 2 required status checks are expected.
```

**Changes:**
- Use `secrets.RELEASE_TOKEN` (fine-grained PAT) in the checkout step so `git push` authenticates as the repo admin
- The `master` ruleset has been updated to include `RepositoryRole(admin)` as a bypass actor

**Setup required:**
1. Create a fine-grained PAT scoped to this repo with `Contents: Read and write`
2. Store it as a repository secret named `RELEASE_TOKEN`