### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jmxsh
 
+[![Homebrew](https://img.shields.io/badge/homebrew-nyg%2Fjmxsh-FBB040?logo=homebrew&logoColor=FBB040)](https://github.com/nyg/homebrew-jmxsh)
+
 > Interactive command-line JMX client for monitoring and managing Java applications.
 
 **Website: [jmx.sh](https://jmx.sh)**
@@ -89,6 +91,12 @@ echo "open localhost:9999 && beans" | java -jar jmxsh-<version>.jar -n
 ```
 
 ## Installation
+
+### Homebrew (macOS & Linux)
+
+```bash
+brew install nyg/jmxsh/jmxsh
+```
 
 ### JAR (all platforms)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,11 @@
       <h2>Quick Start</h2>
       <div class="grid">
         <div class="card">
+          <h3>Homebrew</h3>
+          <p>Install on macOS or Linux with Homebrew:</p>
+          <pre><code>brew install nyg/jmxsh/jmxsh</code></pre>
+        </div>
+        <div class="card">
           <h3>JAR</h3>
           <p>Download the release JAR and run it directly:</p>
           <pre><code>java -jar jmxsh-&lt;version&gt;.jar</code></pre>


### PR DESCRIPTION
## Summary

Add documentation for installing jmxsh via Homebrew using the `nyg/jmxsh` tap.

### Changes

- **README.md**: Added a Homebrew badge (shields.io) to the header and a new `### Homebrew (macOS & Linux)` section under Installation
- **docs/index.html**: Added a Homebrew card to the Quick Start grid on jmx.sh

### Install command

```sh
brew install nyg/jmxsh/jmxsh
```

Tap repo: https://github.com/nyg/homebrew-jmxsh