### PR TITLE
feat: XDG Base Directory compliance for command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ sudo apt update && sudo apt install jmxsh
 - **Script mode** — automate JMX operations via files or piped input
 - **Verbose control** — silent, brief, or verbose output modes
 - **Cross-platform** — runs anywhere Java runs (JAR, DEB, RPM)
+- **XDG Base Directory compliance** — command history stored in `$XDG_STATE_HOME/jmxsh/` (defaults to `~/.local/state/jmxsh/`), keeping your home directory clean
 
 ## Usage
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,7 @@
   <!-- Hero -->
   <header class="hero">
     <div class="container">
+      <img src="favicon.png" alt="" class="hero-icon" width="100" height="100">
       <h1>jmx<span class="accent">.sh</span></h1>
       <p class="tagline">Interactive command-line JMX client for monitoring and managing Java applications.</p>
       <div class="hero-actions">
@@ -26,7 +27,7 @@
   <section class="section" id="quickstart">
     <div class="container">
       <h2>Quick Start</h2>
-      <div class="grid">
+      <div class="grid grid-quickstart">
         <div class="card">
           <h3>Homebrew</h3>
           <p>Install on macOS or Linux with Homebrew:</p>
@@ -37,19 +38,13 @@
           <p>Download the release JAR and run it directly:</p>
           <pre><code>java -jar jmxsh-&lt;version&gt;.jar</code></pre>
         </div>
-        <div class="card">
-          <h3>Debian/Ubuntu</h3>
-          <p>Add the repository and install:</p>
-          <pre><code>curl -fsSL https://jmx.sh/apt/gpg.asc \
-  | sudo gpg --dearmor \
-    -o /usr/share/keyrings/jmxsh.gpg
-
-echo "deb [signed-by=/usr/share/keyrings/jmxsh.gpg] \
-  https://jmx.sh/apt stable main" \
-  | sudo tee /etc/apt/sources.list.d/jmxsh.list
-
+      </div>
+      <div class="card card-fullwidth">
+        <h3>Debian/Ubuntu</h3>
+        <p>Add the repository and install:</p>
+        <pre><code>curl -fsSL https://jmx.sh/apt/gpg.asc | sudo gpg --dearmor -o /usr/share/keyrings/jmxsh.gpg
+echo "deb [signed-by=/usr/share/keyrings/jmxsh.gpg] https://jmx.sh/apt stable main" | sudo tee /etc/apt/sources.list.d/jmxsh.list
 sudo apt update &amp;&amp; sudo apt install jmxsh</code></pre>
-        </div>
       </div>
     </div>
   </section>
@@ -181,6 +176,11 @@ null
           <div class="feature-icon">🔊</div>
           <h3>Verbose Control</h3>
           <p>Silent, brief, or verbose output modes.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">📂</div>
+          <h3>XDG Compliant</h3>
+          <p>Follows the XDG Base Directory spec — keeps your home directory clean.</p>
         </div>
       </div>
     </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -88,6 +88,15 @@ code {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
+/* Quick Start: 2 cards side-by-side, Debian/Ubuntu full width below */
+.grid-quickstart {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.card-fullwidth {
+  margin-top: 1.5rem;
+}
+
 /* ---- Cards ---- */
 
 .card {
@@ -140,6 +149,12 @@ code {
   font-weight: 800;
   letter-spacing: -0.03em;
   font-family: var(--font-mono);
+}
+
+.hero-icon {
+  display: block;
+  margin: 0 auto 1.5rem;
+  border-radius: 20px;
 }
 
 .hero .accent { color: var(--accent); }
@@ -319,5 +334,6 @@ tbody td code {
   .hero .tagline { font-size: 1rem; }
   .section { padding: 3rem 1rem; }
   .grid { grid-template-columns: 1fr; }
+  .grid-quickstart { grid-template-columns: 1fr; }
   .terminal { font-size: 0.75rem; }
 }

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
@@ -4,6 +4,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,6 +24,7 @@ import org.cyclopsgroup.jmxterm.io.InputStreamCommandInput;
 import org.cyclopsgroup.jmxterm.io.JlineCommandInput;
 import org.cyclopsgroup.jmxterm.io.PrintStreamCommandOutput;
 import org.cyclopsgroup.jmxterm.io.VerboseLevel;
+import org.cyclopsgroup.jmxterm.utils.XdgDirectories;
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -89,11 +93,10 @@ public class CliMain {
           input = new InputStreamCommandInput(System.in);
         } else {
           LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().build();
-          File historyFile = new File(System.getProperty("user.home"), ".jmxterm_history");
-          output.printMessage(
-              "Delete "
-                  + historyFile.getAbsolutePath()
-                  + " if you encounter error right after launching me.");
+          Path historyPath = XdgDirectories.INSTANCE.getHistoryFile();
+          migrateHistory(XdgDirectories.INSTANCE.getLegacyHistoryFile(), historyPath);
+          Files.createDirectories(historyPath.getParent());
+          File historyFile = historyPath.toFile();
           consoleReader.setVariable(LineReader.HISTORY_FILE, historyFile);
           History history = consoleReader.getHistory();
           history.load();
@@ -168,6 +171,17 @@ public class CliMain {
       }
     } finally {
       output.close();
+    }
+  }
+
+  /**
+   * Copies the legacy history file ({@code ~/.jmxterm_history}) to the XDG location if the legacy
+   * file exists and the target does not.
+   */
+  static void migrateHistory(Path legacyPath, Path xdgPath) throws IOException {
+    if (Files.isRegularFile(legacyPath) && !Files.exists(xdgPath)) {
+      Files.createDirectories(xdgPath.getParent());
+      Files.copy(legacyPath, xdgPath, StandardCopyOption.COPY_ATTRIBUTES);
     }
   }
 }

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/XdgDirectories.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/XdgDirectories.java
@@ -1,0 +1,53 @@
+package org.cyclopsgroup.jmxterm.utils;
+
+import java.nio.file.Path;
+import java.util.function.Function;
+
+/**
+ * Resolves paths according to the
+ * <a href="https://specifications.freedesktop.org/basedir-spec/latest/">XDG Base Directory
+ * Specification</a>.
+ */
+public final class XdgDirectories {
+
+  static final String APP_NAME = "jmxsh";
+  static final String HISTORY_FILENAME = "history";
+
+  private final Function<String, String> env;
+  private final String userHome;
+
+  /** Production instance that reads real environment variables. */
+  public static final XdgDirectories INSTANCE =
+      new XdgDirectories(System.getenv()::get, System.getProperty("user.home"));
+
+  /**
+   * @param env function that returns the value of an environment variable (or {@code null})
+   * @param userHome value of the user's home directory
+   */
+  public XdgDirectories(Function<String, String> env, String userHome) {
+    this.env = env;
+    this.userHome = userHome;
+  }
+
+  /**
+   * Returns the XDG state home directory ({@code $XDG_STATE_HOME}, defaulting to
+   * {@code $HOME/.local/state}).
+   */
+  public Path getStateHome() {
+    String xdg = env.apply("XDG_STATE_HOME");
+    if (xdg != null && !xdg.isBlank()) {
+      return Path.of(xdg);
+    }
+    return Path.of(userHome, ".local", "state");
+  }
+
+  /** Returns the path where command history should be stored. */
+  public Path getHistoryFile() {
+    return getStateHome().resolve(APP_NAME).resolve(HISTORY_FILENAME);
+  }
+
+  /** Returns the legacy history file path ({@code ~/.jmxterm_history}). */
+  public Path getLegacyHistoryFile() {
+    return Path.of(userHome, ".jmxterm_history");
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/boot/CliMainTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/boot/CliMainTest.java
@@ -1,0 +1,50 @@
+package org.cyclopsgroup.jmxterm.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CliMainTest {
+
+  @Test
+  void migrateHistoryCopiesLegacyFileWhenTargetMissing(@TempDir Path tmp) throws IOException {
+    Path legacy = tmp.resolve("legacy_history");
+    Files.writeString(legacy, "old-history-content");
+
+    Path target = tmp.resolve("xdg/jmxsh/history");
+
+    CliMain.migrateHistory(legacy, target);
+
+    assertThat(target).exists().hasContent("old-history-content");
+    assertThat(legacy).exists().hasContent("old-history-content");
+  }
+
+  @Test
+  void migrateHistorySkipsWhenTargetAlreadyExists(@TempDir Path tmp) throws IOException {
+    Path legacy = tmp.resolve("legacy_history");
+    Files.writeString(legacy, "old-content");
+
+    Path target = tmp.resolve("xdg/jmxsh/history");
+    Files.createDirectories(target.getParent());
+    Files.writeString(target, "new-content");
+
+    CliMain.migrateHistory(legacy, target);
+
+    assertThat(target).hasContent("new-content");
+  }
+
+  @Test
+  void migrateHistorySkipsWhenLegacyFileMissing(@TempDir Path tmp) throws IOException {
+    Path legacy = tmp.resolve("nonexistent");
+    Path target = tmp.resolve("xdg/jmxsh/history");
+
+    CliMain.migrateHistory(legacy, target);
+
+    assertThat(target).doesNotExist();
+  }
+}

--- a/src/test/java/org/cyclopsgroup/jmxterm/utils/XdgDirectoriesTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/utils/XdgDirectoriesTest.java
@@ -1,0 +1,47 @@
+package org.cyclopsgroup.jmxterm.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class XdgDirectoriesTest {
+
+  @Test
+  void stateHomeUsesEnvVarWhenSet() {
+    var dirs = new XdgDirectories(_ -> "/custom/state", "/home/testuser");
+    assertThat(dirs.getStateHome()).isEqualTo(Path.of("/custom/state"));
+  }
+
+  @Test
+  void stateHomeFallsBackWhenEnvVarIsNull() {
+    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    assertThat(dirs.getStateHome()).isEqualTo(Path.of("/home/testuser/.local/state"));
+  }
+
+  @Test
+  void stateHomeFallsBackWhenEnvVarIsBlank() {
+    var dirs = new XdgDirectories(_ -> "  ", "/home/testuser");
+    assertThat(dirs.getStateHome()).isEqualTo(Path.of("/home/testuser/.local/state"));
+  }
+
+  @Test
+  void historyFileResolvesUnderStateHome() {
+    var dirs = new XdgDirectories(_ -> "/xdg/state", "/ignored");
+    assertThat(dirs.getHistoryFile()).isEqualTo(Path.of("/xdg/state/jmxsh/history"));
+  }
+
+  @Test
+  void historyFileUsesDefaultStateHome() {
+    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    assertThat(dirs.getHistoryFile())
+        .isEqualTo(Path.of("/home/testuser/.local/state/jmxsh/history"));
+  }
+
+  @Test
+  void legacyHistoryFileIsInHome() {
+    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    assertThat(dirs.getLegacyHistoryFile()).isEqualTo(Path.of("/home/testuser/.jmxterm_history"));
+  }
+}


### PR DESCRIPTION
## Summary

Move command history from `~/.jmxterm_history` to `$XDG_STATE_HOME/jmxsh/history` (defaults to `~/.local/state/jmxsh/history`) following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).

## Changes

### Java
- **New** `XdgDirectories` utility class — resolves `$XDG_STATE_HOME` with fallback to `~/.local/state`, testable via injected env lookup function
- **Updated** `CliMain.java` — uses XDG state directory for history file, creates parent dirs automatically
- **Backward compat** — on first run, copies (does not move) legacy `~/.jmxterm_history` to the new XDG location
- **Removed** the startup message *"Delete ... if you encounter error right after launching me"*

### Tests
- `XdgDirectoriesTest` — verifies env var usage, fallback, and path construction
- `CliMainTest` — verifies history migration (copy when old exists, skip when target exists, skip when legacy missing)

### Documentation
- **README.md** — added XDG compliance to the Features list
- **Website (index.html)** — added favicon icon to hero section, added XDG Compliant feature card, reworked Quick Start from 3 equal columns to 2+1 layout so Debian/Ubuntu commands are fully visible
- **Website (style.css)** — hero icon styling, Quick Start grid adjustments

## Notes
- Uses XDG on all platforms including macOS (no `~/Library` special-casing)
- No new dependencies — just `System.getenv()` + `java.nio.file.Path`
