### PR TITLE
chore: add Lombok and use it throughout the codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <maven.compiler.release>25</maven.compiler.release>
 
     <!-- Third-party dependencies -->
+    <lombok.version>1.18.46</lombok.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.18</logback.version>
     <picocli.version>4.7.7</picocli.version>
@@ -62,6 +63,12 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
@@ -125,6 +132,20 @@
   <build>
     <finalName>${dist.finalName}</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/src/main/java/org/cyclopsgroup/jmxterm/Command.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/Command.java
@@ -6,8 +6,7 @@ import java.util.Objects;
 
 import javax.management.JMException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import picocli.CommandLine.Option;
 
@@ -18,9 +17,8 @@ import picocli.CommandLine.Option;
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@Slf4j
 public abstract class Command implements Completable {
-  private static final Logger LOG = LoggerFactory.getLogger(Command.class);
-
   private boolean help;
 
   private Session session;
@@ -86,8 +84,8 @@ public abstract class Command implements Completable {
     try {
       return doSuggestArgument();
     } catch (IOException | JMException e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Couldn't suggest argument", e);
+      if (log.isDebugEnabled()) {
+        log.debug("Couldn't suggest argument", e);
       }
       return null;
     }
@@ -100,8 +98,8 @@ public abstract class Command implements Completable {
     try {
       return doSuggestOption(name);
     } catch (IOException | JMException e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Couldn't suggest option", e);
+      if (log.isDebugEnabled()) {
+        log.debug("Couldn't suggest option", e);
       }
       return null;
     }

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
@@ -30,8 +30,8 @@ import org.jline.reader.History;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.impl.LineReaderImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
 
 import picocli.CommandLine;
 
@@ -40,8 +40,8 @@ import picocli.CommandLine;
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@Slf4j
 public class CliMain {
-  private static final Logger LOG = LoggerFactory.getLogger(CliMain.class);
   private static final PrintWriter STDOUT_WRITER = new PrintWriter(System.out, true);
 
   private static final String COMMAND_PROMPT = "$> ";
@@ -52,7 +52,7 @@ public class CliMain {
     } catch (Exception e) {
       String message = e.getMessage() != null ? e.getMessage() : e.toString();
       System.err.println("# " + message);
-      LOG.error("Fatal error", e);
+      log.error("Fatal error", e);
       System.exit(1);
     }
   }
@@ -117,7 +117,7 @@ public class CliMain {
                         try {
                           history.save();
                         } catch (IOException e) {
-                          LOG.warn("failed to flush command history", e);
+                          log.warn("failed to flush command history", e);
                         }
                       }));
           input = new JlineCommandInput(consoleReader, COMMAND_PROMPT);
@@ -181,7 +181,7 @@ public class CliMain {
         input.close();
       }
     } catch (Exception e) {
-      LOG.error("Fatal startup error", e);
+      log.error("Fatal startup error", e);
       output.printError(e);
       return 1;
     } finally {

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
@@ -2,6 +2,9 @@ package org.cyclopsgroup.jmxterm.boot;
 
 import java.io.File;
 import java.util.Objects;
+
+import lombok.Getter;
+
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -22,6 +25,7 @@ import picocli.CommandLine.Option;
         "",
         "Config file: ${sys:jmxsh.config.file}"
     })
+@Getter
 public class CliMainOptions {
   /** Constant <code>stderr</code> that identifies standard error output */
   public static final String STDERR = "stderr";
@@ -55,69 +59,6 @@ public class CliMainOptions {
   private String user;
 
   private boolean isSecureRmiRegistry;
-
-  /** @return #setInput(String) */
-  public final String getInput() {
-    return input;
-  }
-
-  /** @return #setOutput(String) */
-  public final String getOutput() {
-    return output;
-  }
-
-  /** @return Password for user/password authentication */
-  public final String getPassword() {
-    return password;
-  }
-
-  /** @return #setUrl(String) */
-  public final String getUrl() {
-    return url;
-  }
-
-  /** @return User name for user/password authentication */
-  public final String getUser() {
-    return user;
-  }
-
-  /** @return True if user requested help */
-  public final boolean isHelpRequested() {
-    return helpRequested;
-  }
-
-  /** @return True if quiet (silent) mode is enabled */
-  public final boolean isQuiet() {
-    return quiet;
-  }
-
-  /** @return True if user requested version info */
-  public final boolean isVersionRequested() {
-    return versionRequested;
-  }
-
-  /** @return True if terminal exits on any failure */
-  public final boolean isExitOnFailure() {
-    return exitOnFailure;
-  }
-
-  /** @return True if terminal exits on any failure */
-  public final boolean isAppendToOutput() {
-    return appendToOutput;
-  }
-
-  /** @return True if CLI runs without user interaction, such as piped input */
-  public final boolean isNonInteractive() {
-    return nonInteractive;
-  }
-
-  /**
-   * @return True if the server's RMI registry is protected with SSL/TLS
-   *     (com.sun.management.jmxremote.registry.ssl=true)
-   */
-  public final boolean isSecureRmiRegistry() {
-    return isSecureRmiRegistry;
-  }
 
   /** @param exitOnFailure True if terminal exits on any failure */
   @Option(

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
@@ -23,18 +23,17 @@ import org.cyclopsgroup.jmxterm.io.CommandOutput;
 import org.cyclopsgroup.jmxterm.io.RuntimeIOException;
 import org.cyclopsgroup.jmxterm.io.VerboseLevel;
 import org.cyclopsgroup.jmxterm.utils.EscapingTokenizer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Facade class where commands are maintained and executed
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@Slf4j
 public class CommandCenter {
-  private static final Logger LOG = LoggerFactory.getLogger(CommandCenter.class);
   private static final String COMMAND_DELIMITER = "&&";
   static final String ESCAPE_CHAR_REGEX = "(?<!\\\\)#";
 
@@ -129,7 +128,7 @@ public class CommandCenter {
 
   private void doExecute(String commandName, String[] commandArgs)
       throws JMException, IOException {
-    LOG.debug("executing command: {}", commandName);
+    log.debug("executing command: {}", commandName);
     Command cmd = commandFactory.createCommand(commandName);
     if (cmd instanceof HelpCommand command) {
       command.setCommandCenter(this);

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/ConnectionImpl.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/ConnectionImpl.java
@@ -1,11 +1,15 @@
 package org.cyclopsgroup.jmxterm.cc;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import org.cyclopsgroup.jmxterm.Connection;
 
@@ -14,21 +18,16 @@ import org.cyclopsgroup.jmxterm.Connection;
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 class ConnectionImpl implements Connection {
+
+  @Getter
+  @NonNull
   private final JMXConnector connector;
 
+  @Getter
+  @NonNull
   private final JMXServiceURL url;
-
-  /**
-   * @param connector JMX connector
-   * @param url JMX service URL object
-   */
-  ConnectionImpl(JMXConnector connector, JMXServiceURL url) {
-    Objects.requireNonNull(connector, "JMX connector can't be NULL");
-    Objects.requireNonNull(url, "JMX service URL can't be NULL");
-    this.connector = connector;
-    this.url = url;
-  }
 
   /**
    * Close current connection
@@ -39,11 +38,6 @@ class ConnectionImpl implements Connection {
     connector.close();
   }
 
-  /** @return JMX connector */
-  public final JMXConnector getConnector() {
-    return connector;
-  }
-
   @Override
   public String getConnectorId() throws IOException {
     return connector.getConnectionId();
@@ -52,10 +46,5 @@ class ConnectionImpl implements Connection {
   @Override
   public MBeanServerConnection getServerConnection() throws IOException {
     return connector.getMBeanServerConnection();
-  }
-
-  @Override
-  public final JMXServiceURL getUrl() {
-    return url;
   }
 }

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/ConsoleCompletor.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/ConsoleCompletor.java
@@ -8,19 +8,18 @@ import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Model.OptionSpec;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * JLine completor that handles tab key
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@Slf4j
 public class ConsoleCompletor implements Completer {
-  private static final Logger LOG = LoggerFactory.getLogger(ConsoleCompletor.class);
 
   private final CommandCenter commandCenter;
 
@@ -84,8 +83,8 @@ public class ConsoleCompletor implements Completer {
       List<String> suggestions = cmd.suggestArgument(null);
       addFilteredSuggestions(suggestions, currentWord, candidates);
     } catch (RuntimeException e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Couldn't complete input", e);
+      if (log.isDebugEnabled()) {
+        log.debug("Couldn't complete input", e);
       }
     }
   }

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
@@ -1,5 +1,7 @@
 package org.cyclopsgroup.jmxterm.cc;
 
+import lombok.experimental.UtilityClass;
+
 import org.cyclopsgroup.jmxterm.JavaProcessManager;
 import org.cyclopsgroup.jmxterm.jdk9.Jdk9JavaProcessManager;
 
@@ -8,12 +10,8 @@ import org.cyclopsgroup.jmxterm.jdk9.Jdk9JavaProcessManager;
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
-public final class JPMFactory {
-
-  /** Default constructor that figures out an implementation of JPM */
-  private JPMFactory() {
-    throw new UnsupportedOperationException("Not instantiable");
-  }
+@UtilityClass
+public class JPMFactory {
 
   /** @return Java process manager instance */
   static JavaProcessManager createProcessManager() {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/SessionImpl.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/SessionImpl.java
@@ -13,16 +13,15 @@ import org.cyclopsgroup.jmxterm.JavaProcessManager;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.io.CommandInput;
 import org.cyclopsgroup.jmxterm.io.CommandOutput;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Implementation of {@link Session} which keeps a {@link ConnectionImpl}
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@Slf4j
 class SessionImpl extends Session {
-  private static final Logger LOG = LoggerFactory.getLogger(SessionImpl.class);
 
   private ConnectionImpl connection;
 
@@ -41,10 +40,10 @@ class SessionImpl extends Session {
     if (connection != null) {
       throw new IllegalStateException("Session is already opened");
     }
-    LOG.info("connecting to {}", url);
+    log.info("connecting to {}", url);
     JMXConnector connector = doConnect(url, env);
     connection = new ConnectionImpl(connector, url);
-    LOG.info("connected to {}", url);
+    log.info("connected to {}", url);
   }
 
   @Override
@@ -52,7 +51,7 @@ class SessionImpl extends Session {
     if (connection == null) {
       return;
     }
-    LOG.info("disconnecting from JMX server");
+    log.info("disconnecting from JMX server");
     try {
       connection.close();
     } finally {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeanCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeanCommand.java
@@ -15,12 +15,11 @@ import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;
 import org.cyclopsgroup.jmxterm.io.RuntimeIOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to display or set current bean
@@ -32,8 +31,8 @@ import picocli.CommandLine.Parameters;
     description = "Display or set current selected MBean. ",
     footer = "Without any parameter, it displays current selected bean, "
             + "otherwise it selects the bean defined by the first parameter. eg. bean java.lang:type=Memory")
+@Slf4j
 public class BeanCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(BeanCommand.class);
   /**
    * Get full MBean name with given bean name, domain and session
    *
@@ -132,7 +131,7 @@ public class BeanCommand extends Command {
     MBeanServerConnection con = session.getConnection().getServerConnection();
     con.getMBeanInfo(name);
     session.setBean(beanName);
-    LOG.debug("selected bean: {}", beanName);
+    log.debug("selected bean: {}", beanName);
     session.getOutput().printMessage("bean is set to " + beanName);
   }
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/CloseCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/CloseCommand.java
@@ -2,10 +2,9 @@ package org.cyclopsgroup.jmxterm.cmd;
 
 import java.io.IOException;
 import org.cyclopsgroup.jmxterm.Command;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to close current connection
@@ -13,11 +12,11 @@ import picocli.CommandLine;
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "close", description = "Close current JMX connection")
+@Slf4j
 public class CloseCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(CloseCommand.class);
   @Override
   public void execute() throws IOException {
-    LOG.info("closing JMX connection");
+    log.info("closing JMX connection");
     getSession().disconnect();
     getSession().getOutput().printMessage("disconnected");
   }

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainCommand.java
@@ -8,11 +8,10 @@ import java.util.Objects;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Get or set current selected domain
@@ -25,8 +24,8 @@ import picocli.CommandLine.Parameters;
     footer =
         "With a parameter, parameter defined domain is selected, otherwise it displays current selected domain."
             + " eg. domain java.lang")
+@Slf4j
 public class DomainCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(DomainCommand.class);
   /**
    * Get domain name from given domain expression
    *
@@ -80,7 +79,7 @@ public class DomainCommand extends Command {
       session.getOutput().printMessage("domain is unset");
     } else {
       session.setDomain(domainName);
-      LOG.debug("selected domain: {}", domainName);
+      log.debug("selected domain: {}", domainName);
       session.getOutput().printMessage("domain is set to " + session.getDomain());
     }
   }

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -17,12 +17,11 @@ import javax.management.openmbean.CompositeDataSupport;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.io.ValueOutputFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Get value of MBean attribute(s)
@@ -33,8 +32,8 @@ import picocli.CommandLine.Parameters;
     name = "get",
     description = "Get value of MBean attribute(s)",
     footer = "* stands for all attributes. eg. get Attribute1 Attribute2 or get *")
+@Slf4j
 public class GetCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(GetCommand.class);
   private List<String> attributes = new ArrayList<>();
 
   private String bean;
@@ -155,7 +154,7 @@ public class GetCommand extends Command {
     if (attributes.isEmpty()) {
       throw new IllegalArgumentException("Please specify at least one attribute");
     }
-    LOG.debug("getting attribute(s) {} from bean {}", attributes, bean);
+    log.debug("getting attribute(s) {} from bean {}", attributes, bean);
     displayAttributes();
   }
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/JvmsCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/JvmsCommand.java
@@ -8,11 +8,10 @@ import javax.management.JMException;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.JavaProcess;
 import org.cyclopsgroup.jmxterm.Session;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to list all running local JVM processes
@@ -20,15 +19,15 @@ import picocli.CommandLine.Option;
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "jvms", description = "List all running local JVM processes")
+@Slf4j
 public class JvmsCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(JvmsCommand.class);
   private boolean pidOnly;
 
   @Override
   public void execute() throws IOException, JMException {
     Session session = getSession();
     List<JavaProcess> processList = session.getProcessManager().list();
-    LOG.debug("found {} running JVM processes", processList.size());
+    log.debug("found {} running JVM processes", processList.size());
     for (JavaProcess p : processList) {
       if (pidOnly) {
         session.getOutput().println(String.valueOf(p.getProcessId()));

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
@@ -11,12 +11,11 @@ import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Connection;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to open JMX connection
@@ -35,8 +34,8 @@ import picocli.CommandLine.Parameters;
          open jmxmp://localhost:9991,
          open service:jmx:jmxmp://localhost:9991,
          open jmx:service:...""")
+@Slf4j
 public class OpenCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(OpenCommand.class);
   private String password;
 
   private String url;
@@ -49,7 +48,7 @@ public class OpenCommand extends Command {
   public void execute() throws IOException {
     Session session = getSession();
     if (url != null) {
-      LOG.info("opening JMX connection to {}", url);
+      log.info("opening JMX connection to {}", url);
     }
     if (url == null) {
       Connection con = session.getConnection();

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/RunCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/RunCommand.java
@@ -19,12 +19,11 @@ import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;
 import org.cyclopsgroup.jmxterm.io.ValueOutputFormat;
 import org.cyclopsgroup.jmxterm.utils.ValueFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to run an MBean operation
@@ -35,8 +34,8 @@ import picocli.CommandLine.Parameters;
     name = "run",
     description = "Invoke an MBean operation",
     footer = "Syntax is \n run <operationName> [parameter1] [parameter2]")
+@Slf4j
 public class RunCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(RunCommand.class);
   private String bean;
 
   private String domain;
@@ -88,7 +87,7 @@ public class RunCommand extends Command {
       }
     }
     String operationName = parameters.get(0);
-    LOG.debug("invoking operation {} on {}", operationName, beanName);
+    log.debug("invoking operation {} on {}", operationName, beanName);
     ObjectName name = new ObjectName(beanName);
     MBeanServerConnection con = session.getConnection().getServerConnection();
     MBeanInfo beanInfo = con.getMBeanInfo(name);

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
@@ -17,12 +17,11 @@ import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;
 import org.cyclopsgroup.jmxterm.utils.ValueFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to set an attribute
@@ -30,8 +29,8 @@ import picocli.CommandLine.Parameters;
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "set", description = "Set value of an MBean attribute")
+@Slf4j
 public class SetCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(SetCommand.class);
   private List<String> arguments = Collections.emptyList();
 
   private String bean;
@@ -72,7 +71,7 @@ public class SetCommand extends Command {
     }
     Session session = getSession();
     String attributeName = arguments.get(0);
-    LOG.debug("setting attribute {} on bean {}", attributeName, bean);
+    log.debug("setting attribute {} on bean {}", attributeName, bean);
 
     String beanName = BeanCommand.getBeanName(bean, domain, session);
     ObjectName name = new ObjectName(beanName);

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommand.java
@@ -12,11 +12,10 @@ import javax.management.ObjectName;
 
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to subscribe to an MBean notification
@@ -29,8 +28,8 @@ import picocli.CommandLine.Option;
     name = "subscribe",
     description = "Subscribe to the notifications of a bean",
     footer = "Syntax is \n subscribe <bean>")
+@Slf4j
 public class SubscribeCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(SubscribeCommand.class);
   private static Map<ObjectName, NotificationListener> listeners =
       new ConcurrentHashMap<>();
 
@@ -68,7 +67,7 @@ public class SubscribeCommand extends Command {
       throw new IllegalArgumentException(
           "Please specify MBean to invoke either using -b option or bean command");
     }
-    LOG.debug("subscribing to notifications from {}", beanName);
+    log.debug("subscribing to notifications from {}", beanName);
 
     ObjectName name = new ObjectName(beanName);
     if (!listeners.containsKey(name)) {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommand.java
@@ -9,11 +9,10 @@ import javax.management.ObjectName;
 
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to subscribe to an MBean notification
@@ -25,8 +24,8 @@ import picocli.CommandLine.Option;
     name = "unsubscribe",
     description = "Unsubscribe the notifications of an earlier subscribed bean",
     footer = "Syntax is \n unsubscribe <bean>")
+@Slf4j
 public class UnsubscribeCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(UnsubscribeCommand.class);
   private String bean;
 
   private String domain;
@@ -39,7 +38,7 @@ public class UnsubscribeCommand extends Command {
       throw new IllegalArgumentException(
           "Please specify MBean to invoke either using -b option or bean command");
     }
-    LOG.debug("unsubscribing from notifications on {}", beanName);
+    log.debug("unsubscribing from notifications on {}", beanName);
 
     ObjectName name = new ObjectName(beanName);
     NotificationListener listener = SubscribeCommand.getListeners().remove(name);

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/WatchCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/WatchCommand.java
@@ -18,13 +18,12 @@ import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.io.CommandOutput;
 import org.cyclopsgroup.jmxterm.io.JlineCommandInput;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.jline.reader.impl.LineReaderImpl;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command to watch an MBean attribute TODO Consider the use case for CSV file backend generation
@@ -35,8 +34,8 @@ import picocli.CommandLine.Parameters;
     name = "watch",
     description = "Watch the value of one MBean attribute constantly",
     footer = "DO NOT call this command in a script and expect decent output")
+@Slf4j
 public class WatchCommand extends Command {
-  private static final Logger LOG = LoggerFactory.getLogger(WatchCommand.class);
   private static final class ConsoleOutput extends Output {
     private final LineReaderImpl console;
 
@@ -117,7 +116,7 @@ public class WatchCommand extends Command {
       throw new IllegalStateException("Please specify a bean using bean command first.");
     }
 
-    LOG.debug("starting watch on {} for attributes {}", beanName, attributes);
+    log.debug("starting watch on {} for attributes {}", beanName, attributes);
 
     final ObjectName name = new ObjectName(beanName);
     final MBeanServerConnection con = session.getConnection().getServerConnection();
@@ -151,7 +150,7 @@ public class WatchCommand extends Command {
       System.in.read();
       System.out.println();
       executor.shutdownNow();
-      LOG.debug("watch stopped");
+      log.debug("watch stopped");
     }
 
     session.getOutput().println("");

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutput.java
@@ -1,32 +1,23 @@
 package org.cyclopsgroup.jmxterm.io;
 
-import java.util.Objects;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Command output implementation where detail message can be turned on and off dynamically
  *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
+@Slf4j
+@RequiredArgsConstructor
 public class VerboseCommandOutput extends CommandOutput {
-  private static final Logger LOG = LoggerFactory.getLogger(VerboseCommandOutput.class);
 
-  private final VerboseCommandOutputConfig config;
-
+  @NonNull
   private final CommandOutput output;
 
-  /**
-   * @param output Proxy'ed output
-   * @param config Dynamic config
-   */
-  public VerboseCommandOutput(CommandOutput output, VerboseCommandOutputConfig config) {
-    Objects.requireNonNull(output, "The proxy'ed output can't be NULL");
-    Objects.requireNonNull(config, "Config can't be NULL");
-    this.output = output;
-    this.config = config;
-  }
+  @NonNull
+  private final VerboseCommandOutputConfig config;
 
   @Override
   public void close() {
@@ -40,7 +31,7 @@ public class VerboseCommandOutput extends CommandOutput {
 
   @Override
   public void printError(Throwable e) {
-    LOG.error("command execution error: {}", e.getMessage(), e);
+    log.error("command execution error: {}", e.getMessage(), e);
     if (config.getVerboseLevel() != VerboseLevel.SILENT) {
       output.printMessage("#" + e.getMessage());
     }

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcess.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcess.java
@@ -2,7 +2,10 @@ package org.cyclopsgroup.jmxterm.jdk9;
 
 import java.io.IOException;
 
-import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
 import org.cyclopsgroup.jmxterm.JavaProcess;
 
 import com.sun.tools.attach.AttachNotSupportedException;
@@ -14,20 +17,12 @@ import com.sun.tools.attach.VirtualMachineDescriptor;
  *
  * @author <a href="https://github.com/nyg">nyg</a>
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class Jdk9JavaProcess implements JavaProcess {
 
+  @NonNull
   private final VirtualMachineDescriptor vmd;
   private final String address;
-
-  /**
-   * @param vmd Local VM
-   * @param address Connector address, if any
-   */
-  Jdk9JavaProcess(VirtualMachineDescriptor vmd, String address) {
-    Objects.requireNonNull(vmd, "VirtualMachineDescriptor can't be NULL");
-    this.vmd = vmd;
-    this.address = address;
-  }
 
   @Override
   public String getDisplayName() {

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/AppConfig.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/AppConfig.java
@@ -7,6 +7,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import lombok.Getter;
+
 /**
  * Loads application configuration from {@code $XDG_CONFIG_HOME/jmxsh/config.properties}. All
  * settings fall back to defaults when the file is absent or a key is missing.
@@ -16,6 +18,7 @@ public final class AppConfig {
   private static final String KEY_LOGGING_FILE_ENABLED = "logging.file.enabled";
   private static final boolean DEFAULT_LOGGING_FILE_ENABLED = false;
 
+  @Getter
   private final boolean loggingFileEnabled;
 
   private AppConfig(boolean loggingFileEnabled) {
@@ -57,11 +60,6 @@ public final class AppConfig {
       return false;
     }
     return defaultValue;
-  }
-
-  /** Returns {@code true} if log-to-file is enabled. Defaults to {@code false}. */
-  public boolean isLoggingFileEnabled() {
-    return loggingFileEnabled;
   }
 
   private static final String DEFAULT_CONFIG_CONTENT =

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/XdgDirectories.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/XdgDirectories.java
@@ -3,11 +3,14 @@ package org.cyclopsgroup.jmxterm.utils;
 import java.nio.file.Path;
 import java.util.function.Function;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Resolves paths according to the
  * <a href="https://specifications.freedesktop.org/basedir-spec/latest/">XDG Base Directory
  * Specification</a>.
  */
+@RequiredArgsConstructor
 public final class XdgDirectories {
 
   static final String APP_NAME = "jmxsh";
@@ -21,15 +24,6 @@ public final class XdgDirectories {
   /** Production instance that reads real environment variables. */
   public static final XdgDirectories INSTANCE =
       new XdgDirectories(System.getenv()::get, System.getProperty("user.home"));
-
-  /**
-   * @param env function that returns the value of an environment variable (or {@code null})
-   * @param userHome value of the user's home directory
-   */
-  public XdgDirectories(Function<String, String> env, String userHome) {
-    this.env = env;
-    this.userHome = userHome;
-  }
 
   /**
    * Returns the XDG state home directory ({@code $XDG_STATE_HOME}, defaulting to


### PR DESCRIPTION
## Summary

Adds [Lombok](https://projectlombok.org/) as a `provided`-scope dependency and applies its annotations throughout the codebase to eliminate boilerplate.

### Changes

**`pom.xml`**
- Add `org.projectlombok:lombok:1.18.46` (`provided` scope)
- Add `<annotationProcessorPaths>` to `maven-compiler-plugin`

**`@Slf4j` — 17 classes**
Replaced `private static final Logger LOG = LoggerFactory.getLogger(X.class)` with `@Slf4j`, eliminating the static field and renaming `LOG.` → `log.` throughout.

**`@UtilityClass` — `JPMFactory`**
Replaced the private throw-constructor with `@UtilityClass`.

**`@RequiredArgsConstructor` + `@NonNull` + `@Getter` — value objects**
- `ConnectionImpl`: `@NonNull` on both fields, `@RequiredArgsConstructor(access=PACKAGE)`, `@Getter` on both fields — replaces 6-line constructor and two getter methods
- `VerboseCommandOutput`: `@NonNull` + `@RequiredArgsConstructor` — replaces constructor with null checks
- `Jdk9JavaProcess`: `@NonNull` on `vmd`, `@RequiredArgsConstructor(access=PACKAGE)` — replaces constructor
- `XdgDirectories`: `@RequiredArgsConstructor` — replaces constructor

**`@Getter` — `CliMainOptions` and `AppConfig`**
- `CliMainOptions`: class-level `@Getter` removes 12 trivial getter methods; all setter methods (picocli `@Option`) are preserved
- `AppConfig`: field-level `@Getter` on `loggingFileEnabled` removes one getter method

### Notes
- Lombok is `provided` scope — not included in the uber JAR
- Setter methods and picocli `@Option`/`@Parameters` annotations were intentionally kept on setters (not moved to fields) since they are called directly in unit tests
- `final` removed from generated getters in `ConnectionImpl` and `CliMainOptions` — accepted change since no external subclasses exist

All 172 tests pass (`mvn verify`).