### PR TITLE
chore: remove @author javadoc tags

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,13 @@ Both RMI and JMXMP protocols are supported. URL formats:
 
 ## Conventions
 
+### Branching & Pull Requests
+
+**Never commit directly to `master`.** Always:
+1. Create a new branch (e.g. `feat/my-feature`, `fix/my-fix`, `chore/my-task`)
+2. Commit your changes on that branch
+3. Open a pull request against `master`
+
 ### Commit Messages
 
 Follow **Conventional Commits**: `type(scope): description`

--- a/src/main/java/org/cyclopsgroup/jmxterm/Command.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/Command.java
@@ -15,7 +15,6 @@ import picocli.CommandLine.Option;
  * worry about concurrency. Command is transient, every command in console creates a new instance of
  * Command object which is disposed after execution finishes.
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Slf4j
 public abstract class Command implements Completable {

--- a/src/main/java/org/cyclopsgroup/jmxterm/CommandFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/CommandFactory.java
@@ -5,7 +5,6 @@ import java.util.Map;
 /**
  * Factory which create Command instance based on command name
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public interface CommandFactory {
   /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/Connection.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/Connection.java
@@ -7,7 +7,6 @@ import javax.management.remote.JMXServiceURL;
 /**
  * Identifies lifecycle of a connection
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public interface Connection {
   /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/JavaProcess.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/JavaProcess.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 /**
  * Identifies a running JVM process
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public interface JavaProcess {
   /** @return Display name of process */

--- a/src/main/java/org/cyclopsgroup/jmxterm/JavaProcessManager.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/JavaProcessManager.java
@@ -5,7 +5,6 @@ import java.util.List;
 /**
  * Java process manager
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public abstract class JavaProcessManager {
   /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/Session.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/Session.java
@@ -18,7 +18,6 @@ import org.cyclopsgroup.jmxterm.io.VerboseLevel;
  * JMX communication context. This class exists for the whole lifecycle of a command execution. It
  * is NOT thread safe. The caller(CommandCenter) makes sure all calls are synchronized.
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public abstract class Session implements VerboseCommandOutputConfig {
   private String bean;

--- a/src/main/java/org/cyclopsgroup/jmxterm/SyntaxUtils.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/SyntaxUtils.java
@@ -15,7 +15,6 @@ import org.cyclopsgroup.jmxterm.utils.ValueFormat;
 /**
  * Utility class for syntax checking
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public final class SyntaxUtils {
   /** NULL string identifier */

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
@@ -38,7 +38,6 @@ import picocli.CommandLine;
 /**
  * Main class invoked directly from command line
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Slf4j
 public class CliMain {

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
@@ -11,7 +11,6 @@ import picocli.CommandLine.Option;
 /**
  * Options for main class
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Command(
     name = "jmxterm",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Facade class where commands are maintained and executed
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Slf4j
 public class CommandCenter {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/ConnectionImpl.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/ConnectionImpl.java
@@ -16,7 +16,6 @@ import org.cyclopsgroup.jmxterm.Connection;
 /**
  * Identifies a JMX connection
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 class ConnectionImpl implements Connection {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/ConsoleCompletor.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/ConsoleCompletor.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * JLine completor that handles tab key
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Slf4j
 public class ConsoleCompletor implements Completer {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/HelpCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/HelpCommand.java
@@ -12,7 +12,6 @@ import picocli.CommandLine.Parameters;
 /**
  * Command that display a help message
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Command(
     name = "help",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
@@ -8,7 +8,6 @@ import org.cyclopsgroup.jmxterm.jdk9.Jdk9JavaProcessManager;
 /**
  * Internal factory class to create JPM instance
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @UtilityClass
 public class JPMFactory {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/PredefinedCommandFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/PredefinedCommandFactory.java
@@ -28,7 +28,6 @@ import picocli.CommandLine;
  * Factory class of commands which knows how to create Command class with given command name.
  * Commands are discovered via their {@link CommandLine.Command} annotations.
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class PredefinedCommandFactory implements CommandFactory {
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/SessionImpl.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/SessionImpl.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Implementation of {@link Session} which keeps a {@link ConnectionImpl}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Slf4j
 class SessionImpl extends Session {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/TypeMapCommandFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/TypeMapCommandFactory.java
@@ -11,7 +11,6 @@ import org.cyclopsgroup.jmxterm.CommandFactory;
 /**
  * CommandFactory implementation based on a Map of command types
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class TypeMapCommandFactory implements CommandFactory {
   private final Map<String, Class<? extends Command>> commandTypes;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeanCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeanCommand.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to display or set current bean
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "bean",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeansCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeansCommand.java
@@ -16,7 +16,6 @@ import picocli.CommandLine.Option;
 /**
  * Command that shows list of beans
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "beans",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/CloseCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/CloseCommand.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to close current connection
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "close", description = "Close current JMX connection")
 @Slf4j

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainCommand.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Get or set current selected domain
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "domain",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainsCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainsCommand.java
@@ -13,7 +13,6 @@ import picocli.CommandLine;
 /**
  * List domains for JMX connection
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "domains", description = "List all available domain names")
 public class DomainsCommand extends Command {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Get value of MBean attribute(s)
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "get",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
@@ -26,7 +26,6 @@ import picocli.CommandLine.Option;
 /**
  * Command that displays attributes and operations of an MBean
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "info",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/JvmsCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/JvmsCommand.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to list all running local JVM processes
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "jvms", description = "List all running local JVM processes")
 @Slf4j

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to open JMX connection
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "open",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/QuitCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/QuitCommand.java
@@ -9,7 +9,6 @@ import picocli.CommandLine;
 /**
  * Command to terminate the console
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "quit", aliases = {"exit", "bye"}, description = "Terminate console and exit")
 public class QuitCommand extends Command {

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/RunCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/RunCommand.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to run an MBean operation
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "run",

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to set an attribute
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "set", description = "Set value of an MBean attribute")
 @Slf4j

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/WatchCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/WatchCommand.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command to watch an MBean attribute TODO Consider the use case for CSV file backend generation
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(
     name = "watch",

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/CommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/CommandInput.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 /**
  * An abstract class that provides command line input line by line
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public abstract class CommandInput implements Closeable {
   @Override

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/CommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/CommandOutput.java
@@ -3,7 +3,6 @@ package org.cyclopsgroup.jmxterm.io;
 /**
  * General abstract class to output message and values
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public abstract class CommandOutput {
   /** Close the output; */

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandInput.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 /**
  * Implementation of CommandInput with given File
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class FileCommandInput extends CommandInput {
   private final LineNumberReader in;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandOutput.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 /**
  * Output with a file
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class FileCommandOutput extends CommandOutput {
   private final PrintWriter fileWriter;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/InputStreamCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/InputStreamCommandInput.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 /**
  * Implementation of {@link CommandInput} with an input stream
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class InputStreamCommandInput extends CommandInput {
   private final LineNumberReader reader;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/JlineCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/JlineCommandInput.java
@@ -7,7 +7,6 @@ import org.jline.reader.impl.LineReaderImpl;
 /**
  * Implementation of input that reads command from jloin console input
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class JlineCommandInput extends CommandInput {
   private final LineReaderImpl console;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/PrintStreamCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/PrintStreamCommandOutput.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 /**
  * Implementation of CommandOutput where output is written in given PrintStream objects
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class PrintStreamCommandOutput extends CommandOutput {
   private final PrintStream messageOutput;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/RuntimeIOException.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/RuntimeIOException.java
@@ -6,7 +6,6 @@ import java.io.Serial;
 /**
  * Unchecked version of IOException
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class RuntimeIOException extends RuntimeException {
   @Serial

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/UnimplementedCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/UnimplementedCommandInput.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 /**
  * Unimplemented version of command input
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class UnimplementedCommandInput extends CommandInput {
   @Override

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormat.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormat.java
@@ -11,7 +11,6 @@ import javax.management.openmbean.CompositeData;
 /**
  * A utility to print out object values in particular format.
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class ValueOutputFormat {
   private final int indentSize;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutput.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Command output implementation where detail message can be turned on and off dynamically
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutputConfig.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutputConfig.java
@@ -3,7 +3,6 @@ package org.cyclopsgroup.jmxterm.io;
 /**
  * Dynamic config for {@link VerboseCommandOutput}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public interface VerboseCommandOutputConfig {
   /** @return Dynamic value of verbose level */

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseLevel.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseLevel.java
@@ -3,7 +3,6 @@ package org.cyclopsgroup.jmxterm.io;
 /**
  * Level of verbose option
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public enum VerboseLevel {
   /** Nothing is written out except returned values */

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/WriterCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/WriterCommandOutput.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 /**
  * A command output that writes result and message to given writers
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class WriterCommandOutput extends CommandOutput {
   private final Writer messageOutput;

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcess.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcess.java
@@ -15,7 +15,6 @@ import com.sun.tools.attach.VirtualMachineDescriptor;
 /**
  * JDK9 specific implementation of {@link JavaProcess}
  *
- * @author <a href="https://github.com/nyg">nyg</a>
  */
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class Jdk9JavaProcess implements JavaProcess {

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManager.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManager.java
@@ -15,7 +15,6 @@ import com.sun.tools.attach.VirtualMachineDescriptor;
 /**
  * JDK9 specific java process manager
  *
- * @author <a href="https://github.com/nyg">nyg</a>
  */
 public class Jdk9JavaProcessManager extends JavaProcessManager {
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/package-info.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/package-info.java
@@ -1,6 +1,5 @@
 /**
  * Classes to implement {@link org.cyclopsgroup.jmxterm.JavaProcessManager} in JDK9 specific way
  *
- * @author <a href="https://github.com/nyg">nyg</a>
  */
 package org.cyclopsgroup.jmxterm.jdk9;

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/ValueFormat.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/ValueFormat.java
@@ -5,7 +5,6 @@ package org.cyclopsgroup.jmxterm.utils;
  * attribute value or parameter of operation. It's NOT designed to parse MBean name or other type of
  * input.
  *
- * @author $Author$
  * @version $Revision$ in $Change$ submitted at $DateTime$
  */
 public final class ValueFormat {

--- a/src/test/java/org/cyclopsgroup/jmxterm/MockConnection.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/MockConnection.java
@@ -7,7 +7,6 @@ import javax.management.remote.JMXServiceURL;
 /**
  * Mock Connection implementation for testing purpose
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class MockConnection implements Connection {
   private final MBeanServerConnection con;

--- a/src/test/java/org/cyclopsgroup/jmxterm/MockSession.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/MockSession.java
@@ -13,7 +13,6 @@ import org.cyclopsgroup.jmxterm.jdk9.Jdk9JavaProcessManager;
 /**
  * Mocked version of {@link Session} implementation for testing purpose only
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class MockSession extends Session {
   private boolean connected = true;

--- a/src/test/java/org/cyclopsgroup/jmxterm/SelfRecordingCommand.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/SelfRecordingCommand.java
@@ -8,7 +8,6 @@ import picocli.CommandLine.Parameters;
 /**
  * A command for testing that records parameters passed in
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @CommandLine.Command(name = "test", description = "desc")
 public class SelfRecordingCommand extends Command {

--- a/src/test/java/org/cyclopsgroup/jmxterm/SyntaxUtilsTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/SyntaxUtilsTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link SyntaxUtils}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class SyntaxUtilsTest {
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/CommandCenterTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/CommandCenterTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link CommandCenter}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class CommandCenterTest {
   private CommandCenter cc;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/ConnectionImplTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/ConnectionImplTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link ConnectionImpl}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class ConnectionImplTest {
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link HelpCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class HelpCommandTest {
   private HelpCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/JPMFactoryTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/JPMFactoryTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test of {@link JPMFactory}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class JPMFactoryTest {
   /** Verify JPMFactory can create process manager */

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/SessionImplTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/SessionImplTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link ConnectionImpl}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class SessionImplTest {
   private JMXConnector con;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/BeanCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/BeanCommandTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link BeanCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class BeanCommandTest {
   private final BeanCommand command = new BeanCommand();

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/BeansCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/BeansCommandTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link BeansCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class BeansCommandTest {
   private static final String EOL = System.getProperty("line.separator");

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/CloseCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/CloseCommandTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test of {@link CloseCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class CloseCommandTest {
   private CloseCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/DomainCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/DomainCommandTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test of {@link DomainCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class DomainCommandTest {
   private DomainCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/DomainsCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/DomainsCommandTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link DomainsCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class DomainsCommandTest {
   private DomainsCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link GetCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class GetCommandTest {
 

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link InfoCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class InfoCommandTest {
   private InfoCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/OpenCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/OpenCommandTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case to test {@link OpenCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class OpenCommandTest {
   private OpenCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/QuitCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/QuitCommandTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link QuitCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class QuitCommandTest {
   private QuitCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/RunCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/RunCommandTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link RunCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class RunCommandTest {
   private RunCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SetCommandTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link SetCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class SetCommandTest {
   private SetCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link org.cyclopsgroup.jmxterm.cmd.RunCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class SubscribeCommandTest {
   private SubscribeCommand command;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link RunCommand}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class UnsubscribeCommandTest {
   private SubscribeCommand subscribeCommand;

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandInputTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandInputTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link FileCommandInput}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class FileCommandInputTest {
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandOutputTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandOutputTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link FileCommandOutput}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class FileCommandOutputTest {
   private File testFile;

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/InputStreamCommandInputTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/InputStreamCommandInputTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit test case for class {@link InputStreamCommandInput}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class InputStreamCommandInputTest {
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/PrintStreamCommandOutputTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/PrintStreamCommandOutputTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link PrintStreamCommandOutput}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class PrintStreamCommandOutputTest {
   /** Write something to output and verify what's written */

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormatTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormatTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link ValueOutputFormat}
  *
- * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 class ValueOutputFormatTest {
   /** Print out expression and verify output */

--- a/src/test/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManagerTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManagerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link Jdk9JavaProcessManager}
  *
- * @author <a href="https://github.com/nyg">nyg</a>
  */
 class Jdk9JavaProcessManagerTest {
 

--- a/src/test/java/org/cyclopsgroup/jmxterm/utils/ValueFormatTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/utils/ValueFormatTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case of {@link ValueFormat}
  *
- * @author $Author$
  * @version $Revision$ in $Change$ submitted at $DateTime$
  */
 class ValueFormatTest {


### PR DESCRIPTION
Removes the `@author` Javadoc tag from all 77 Java files. Authorship is already tracked by git history, so these tags are redundant. Keeping `@author` also means they should be maintained as files are changed overtime, which I don't want to do. Original LICENSE stays and attribution is kept in README.md.

Also adds a branching & PR workflow instruction to `.github/copilot-instructions.md`.