### PR TITLE
fix(legacy): modernize legacy code patterns

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,11 +20,41 @@ and dependency graph. Items are organized by category. Each item is labeled with
 - 🟡 **Add `.editorconfig`** — Not present. Ensures consistent indentation, charset, and line endings across IDEs and editors.
 - 🟡 **Add `.gitattributes`** — Not present. Normalizes line endings (`* text=auto`, `*.java text eol=lf`, `*.sh text eol=lf`) and marks binary files.
 
-## GitHub Actions / CI
-
-- 🟡 **Enable CodeQL scanning** — No SAST (static application security testing) is configured. Add a CodeQL workflow for Java to catch security issues in PRs.
-
 ## Testing
 
 - 🟡 **Add test coverage reporting (JaCoCo)** — No coverage tool is configured. Add `jacoco-maven-plugin` to generate reports and optionally enforce minimum coverage thresholds.
 - 🟢 **Address existing TODO in `WatchCommand`** — Line 28: `TODO Consider the use case for CSV file backend generation`. Decide whether to implement or remove the comment.
+
+## Legacy
+
+Items identified as out-of-place in a Java 25 project — dated idioms, dead dependencies,
+fork vestiges, and design patterns that predate modern Java. Organized by category.
+
+### Legacy Dependencies
+
+### Fork Vestiges (jmxterm / jcli lineage)
+
+- 🟢 **`jdk9/` package name** — the `com.sun.tools.attach` Attach API became a first-class public API in JDK 9; the project now targets Java 25. The package and class names (`Jdk9JavaProcess`, `Jdk9JavaProcessManager`) are misleading fossils. Rename to `attach/` with matching class names. (`jdk9/`, `cc/JPMFactory.java`)
+
+### Legacy Java APIs
+
+### Legacy Language Constructs
+
+- 🟡 **`JavaProcessManager` as abstract class with no concrete state** — Both methods are abstract and there is no shared state. This is a pre-Java 8 pattern for defining a contract; it should be an `interface`. (`JavaProcessManager.java`)
+- 🟡 **`CommandInput` and `CommandOutput` as abstract classes** — Both define only abstract methods plus one convenience default — a perfect fit for `interface` with `default` methods in Java 25. (`io/CommandInput.java`, `io/CommandOutput.java`)
+- 🟡 **`WatchCommand` three-class hierarchy for a single-method abstraction** — The `Output` / `ConsoleOutput` / `ReportOutput` class hierarchy exists to abstract a single `printLine(String)` call. A `@FunctionalInterface` (or a lambda) collapses this to one line. (`cmd/WatchCommand.java`)
+
+### Legacy Architecture
+
+- 🟠 **Mutable static listener registry + memory leak in `SubscribeCommand`** — `listeners` is a public mutable static `ConcurrentHashMap` shared across all command instances, coupling `SubscribeCommand` and `UnsubscribeCommand` through global state. Worse: `BeanNotificationListener` is a non-static inner class that holds an implicit reference to its outer `SubscribeCommand` instance. Every registered listener permanently roots that instance (and through it, the `Session`, `Connection`, and `CommandCenter`) preventing garbage collection — a structural memory leak. (`cmd/SubscribeCommand.java`, `cmd/UnsubscribeCommand.java`)
+- 🟡 **Hand-rolled command tokenizer** — `EscapingTokenizer` is a custom regex-and-loop parser; `CommandCenter` splits on delimiters manually. This brittle plumbing predates mature tokenizer libraries and could be simplified or replaced. (`utils/EscapingTokenizer.java`, `cc/CommandCenter.java`)
+- 🟡 **Reflection-heavy command instantiation** — `PredefinedCommandFactory` and `TypeMapCommandFactory` use `getDeclaredConstructor().newInstance()` and `Class.forName()` to create command instances at runtime, forgoing type safety and IDE support. (`cc/PredefinedCommandFactory.java`, `cc/TypeMapCommandFactory.java`)
+- 🟡 **`Runtime.getRuntime().addShutdownHook(new Thread(...))` pattern** — Registering an anonymous `Thread` as a shutdown hook is the pre-virtual-thread way to handle teardown. (`boot/CliMain.java`)
+- 🟡 **Raw `synchronized` locking around session state** — `CommandCenter` guards mutable session state with a raw lock object. `java.util.concurrent.locks.ReentrantLock` provides equivalent semantics with better observability and more flexible lock/unlock control. (`cc/CommandCenter.java`)
+- 🟢 **`JPMFactory` pointless indirection** — The factory exists solely to call `new Jdk9JavaProcessManager()`. The abstraction adds no value and can be inlined at the call site. (`cc/JPMFactory.java`)
+
+### Legacy Code Smells
+
+- 🟡 **Lombok in a Java 25 project** — `@Getter` on simple data holders; `@RequiredArgsConstructor` instead of explicit constructors; `@NonNull` instead of `Objects.requireNonNull()`. Lombok fills language gaps that Java 25 no longer has, and its annotation-processor magic obscures what the compiler actually generates. (`jdk9/Jdk9JavaProcess.java`, `utils/AppConfig.java`, and others)
+- 🟢 **Null-centric API style** — Several methods return `null` to signal absence (e.g., `Completable.getCandidateValues()`, `Command.getSession()`). `Optional` or empty collections express intent more clearly and eliminate null-check boilerplate at call sites. (`Command.java`, `Completable.java`)
+- 🟢 **`UnimplementedCommandInput` misleading name** — This is a deliberate stub/null-object, but the name implies unfinished work. A name like `NoopCommandInput` would better communicate intent. (`io/UnimplementedCommandInput.java`)

--- a/pom.xml
+++ b/pom.xml
@@ -81,11 +81,6 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>

--- a/src/main/java/sh/jmx/jmxsh/Session.java
+++ b/src/main/java/sh/jmx/jmxsh/Session.java
@@ -1,7 +1,7 @@
 package sh.jmx.jmxsh;
 
-import java.io.IOError;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.Objects;
 
@@ -54,8 +54,8 @@ public abstract class Session implements VerboseCommandOutputConfig {
     }
     try {
       disconnect();
-    } catch (Exception e) {
-      throw new IOError(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
     closed = true;
   }

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -1,6 +1,5 @@
 package sh.jmx.jmxsh.boot;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -15,7 +14,7 @@ import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import sh.jmx.jmxsh.SyntaxUtils;
 import sh.jmx.jmxsh.cc.CommandCenter;
-import sh.jmx.jmxsh.cc.ConsoleCompletor;
+import sh.jmx.jmxsh.cc.ConsoleCompleter;
 import sh.jmx.jmxsh.io.CommandInput;
 import sh.jmx.jmxsh.io.CommandOutput;
 import sh.jmx.jmxsh.io.FileCommandInput;
@@ -92,8 +91,7 @@ public class CliMain {
     if (CliMainOptions.STDOUT.equals(options.getOutput())) {
       output = new PrintStreamCommandOutput(System.out, System.err);
     } else {
-      File outputFile = new File(options.getOutput());
-      output = new FileCommandOutput(outputFile, options.isAppendToOutput());
+      output = new FileCommandOutput(Path.of(options.getOutput()), options.isAppendToOutput());
     }
     try {
       CommandInput input;
@@ -105,8 +103,7 @@ public class CliMain {
           Path historyPath = XdgDirectories.INSTANCE.getHistoryFile();
           migrateHistory(XdgDirectories.INSTANCE.getLegacyHistoryFile(), historyPath);
           Files.createDirectories(historyPath.getParent());
-          File historyFile = historyPath.toFile();
-          consoleReader.setVariable(LineReader.HISTORY_FILE, historyFile);
+          consoleReader.setVariable(LineReader.HISTORY_FILE, historyPath);
           History history = consoleReader.getHistory();
           history.load();
           Runtime.getRuntime()
@@ -122,11 +119,11 @@ public class CliMain {
           input = new JlineCommandInput(consoleReader, COMMAND_PROMPT);
         }
       } else {
-        File inputFile = new File(options.getInput());
-        if (!inputFile.isFile()) {
-          throw new FileNotFoundException("File " + inputFile + " is not a valid file");
+        Path inputPath = Path.of(options.getInput());
+        if (!Files.isRegularFile(inputPath)) {
+          throw new FileNotFoundException("File " + inputPath + " is not a valid file");
         }
-        input = new FileCommandInput(new File(options.getInput()));
+        input = new FileCommandInput(inputPath);
       }
       try {
         CommandCenter commandCenter = new CommandCenter(output, input);
@@ -134,7 +131,7 @@ public class CliMain {
           if (input instanceof JlineCommandInput commandInput) {
             commandInput
                 .getConsole()
-                .setCompleter(new ConsoleCompletor(commandCenter));
+                .setCompleter(new ConsoleCompleter(commandCenter));
           }
           if (options.getUrl() != null) {
             Map<String, Object> env = new HashMap<>();

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMainOptions.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMainOptions.java
@@ -1,6 +1,7 @@
 package sh.jmx.jmxsh.boot;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 
 import lombok.Getter;
@@ -13,8 +14,8 @@ import picocli.CommandLine.Option;
  *
  */
 @Command(
-    name = "jmxterm",
-    description = "Main executable of JMX terminal CLI tool",
+    name = "jmxsh",
+    description = "Interactive JMX shell",
     mixinStandardHelpOptions = false,
     versionProvider = VersionProvider.class,
     footer = {
@@ -74,7 +75,7 @@ public class CliMainOptions {
           "Input script file. There can only be one input file. \"stdin\" is the default value which means console input")
   public final void setInput(String file) {
     Objects.requireNonNull(file, "Input file can't be NULL");
-    if (!new File(file).isFile()) {
+    if (!Files.isRegularFile(Path.of(file))) {
       throw new IllegalArgumentException("File " + file + " doesn't exist");
     }
     this.input = file;
@@ -84,7 +85,7 @@ public class CliMainOptions {
   @Option(
       names = {"-n", "--noninteract"},
       description =
-          "Non interactive mode. Use this mode if input doesn't come from human or jmxterm is embedded")
+          "Non interactive mode. Use this mode if input doesn't come from human or jmxsh is embedded")
   public final void setNonInteractive(boolean nonInteractive) {
     this.nonInteractive = nonInteractive;
   }

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -104,7 +104,7 @@ public class CommandCenter {
         command.split(ESCAPE_CHAR_REGEX)[0] // take out all commented out sections
             .replace("\\#", "#"); // fix escaped to non-escaped comment charaters
     // If command includes multiple segments, call them one by one using recursive call
-    if (command.indexOf(COMMAND_DELIMITER) != -1) {
+    if (command.contains(COMMAND_DELIMITER)) {
       String[] commands = command.split(COMMAND_DELIMITER);
       for (String c : commands) {
         execute(c);
@@ -116,7 +116,7 @@ public class CommandCenter {
     final List<String> args = new ArrayList<>(EscapingTokenizer.tokenize(command));
     String commandName = args.remove(0);
     // Leave the rest of arguments for command
-    String[] commandArgs = args.toArray(new String[0]);
+    String[] commandArgs = args.toArray(String[]::new);
     // Call command with parsed command name and arguments
     try {
       doExecute(commandName, commandArgs);

--- a/src/main/java/sh/jmx/jmxsh/cc/ConnectionImpl.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/ConnectionImpl.java
@@ -1,15 +1,11 @@
 package sh.jmx.jmxsh.cc;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
-
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 import sh.jmx.jmxsh.Connection;
 
@@ -17,22 +13,18 @@ import sh.jmx.jmxsh.Connection;
  * Identifies a JMX connection
  *
  */
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-class ConnectionImpl implements Connection {
+record ConnectionImpl(JMXConnector connector, JMXServiceURL url) implements Connection {
 
-  @Getter
-  @NonNull
-  private final JMXConnector connector;
+  ConnectionImpl {
+    Objects.requireNonNull(connector, "connector");
+    Objects.requireNonNull(url, "url");
+  }
 
-  @Getter
-  @NonNull
-  private final JMXServiceURL url;
+  @Override
+  public JMXServiceURL getUrl() {
+    return url;
+  }
 
-  /**
-   * Close current connection
-   *
-   * @throws IOException Communication error
-   */
   void close() throws IOException {
     connector.close();
   }

--- a/src/main/java/sh/jmx/jmxsh/cc/ConsoleCompleter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/ConsoleCompleter.java
@@ -14,17 +14,17 @@ import picocli.CommandLine.Model.OptionSpec;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * JLine completor that handles tab key
+ * JLine completer that handles tab key
  *
  */
 @Slf4j
-public class ConsoleCompletor implements Completer {
+public class ConsoleCompleter implements Completer {
 
   private final CommandCenter commandCenter;
 
   private final List<Candidate> commandNames;
 
-  public ConsoleCompletor(CommandCenter commandCenter) {
+  public ConsoleCompleter(CommandCenter commandCenter) {
     Objects.requireNonNull(commandCenter, "Command center can't be NULL");
     this.commandCenter = commandCenter;
     this.commandNames = commandCenter.getCommandNames().stream()

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
@@ -52,7 +52,7 @@ public class BeanCommand extends Command {
       return null;
     }
     MBeanServerConnection con = session.getConnection().getServerConnection();
-    if (bean.indexOf(':') != -1) {
+    if (bean.contains(":")) {
       try {
         ObjectName name = new ObjectName(bean);
         con.getMBeanInfo(name);

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -2,6 +2,7 @@ package sh.jmx.jmxsh.cmd;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,11 +129,7 @@ public class GetCommand extends Command {
       MBeanServerConnection con = getSession().getConnection().getServerConnection();
       MBeanAttributeInfo[] ais =
           con.getMBeanInfo(new ObjectName(getSession().getBean())).getAttributes();
-      List<String> results = new ArrayList<>(ais.length);
-      for (MBeanAttributeInfo ai : ais) {
-        results.add(ai.getName());
-      }
-      return results;
+      return Arrays.stream(ais).map(MBeanAttributeInfo::getName).toList();
     }
     return null;
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/InfoCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/InfoCommand.java
@@ -64,8 +64,7 @@ public class InfoCommand extends Command {
     for (MBeanAttributeInfo attr : infos) {
       String rw = (attr.isReadable() ? "r" : "") + (attr.isWritable() ? "w" : "");
       session.getOutput().println(
-          String.format(
-              "  %%%-3d - %s (%s, %s)" + (showDescription ? ", %s" : ""),
+          ("  %%%-3d - %s (%s, %s)" + (showDescription ? ", %s" : "")).formatted(
               index++,
               attr.getName(),
               attr.getType(),
@@ -85,8 +84,7 @@ public class InfoCommand extends Command {
     session.getOutput().println(TEXT_NOTIFICATIONS);
     for (MBeanNotificationInfo notification : notificationInfos) {
       session.getOutput().println(
-          String.format(
-              "  %%%-3d - %s(%s)" + (showDescription ? ", %s" : ""),
+          ("  %%%-3d - %s(%s)" + (showDescription ? ", %s" : "")).formatted(
               index++,
               notification.getName(),
               String.join(",", notification.getNotifTypes()),
@@ -116,8 +114,7 @@ public class InfoCommand extends Command {
       String parametersDesc =
           paramDescriptions.isEmpty() ? "" : '\n' + String.join("\n", paramDescriptions);
       session.getOutput().println(
-          String.format(
-              "  %%%-3d - %s %s(%s)" + (showDescription ? ", %s%s" : ""),
+          ("  %%%-3d - %s %s(%s)" + (showDescription ? ", %s%s" : "")).formatted(
               index++,
               op.getReturnType(),
               op.getName(),
@@ -147,8 +144,8 @@ public class InfoCommand extends Command {
             new StringBuilder("             parameters:" + System.lineSeparator());
         for (MBeanParameterInfo paramInfo : paramInfos) {
           String parameter = paramInfo.getName();
-          paramsDesc.append(String.format(
-                  "                 + %-20s : %s" + System.lineSeparator(),
+          paramsDesc.append(
+              ("                 + %-20s : %s" + System.lineSeparator()).formatted(
                   parameter,
                   paramInfo.getDescription()));
           paramTypes.add(paramInfo.getType() + " " + parameter);
@@ -188,18 +185,11 @@ public class InfoCommand extends Command {
     if (operation == null) {
       for (char t : type.toCharArray()) {
         switch (t) {
-          case 'a':
-            displayAttributes(info);
-            break;
-          case 'o':
-            displayOperations(info);
-            break;
-          case 'n':
-            displayNotifications(info);
-            break;
-          default:
-            throw new IllegalArgumentException(
-                "Unrecognizable character " + t + " in type option " + type);
+          case 'a' -> displayAttributes(info);
+          case 'o' -> displayOperations(info);
+          case 'n' -> displayNotifications(info);
+          default -> throw new IllegalArgumentException(
+              "Unrecognizable character " + t + " in type option " + type);
         }
       }
     } else {

--- a/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
@@ -1,7 +1,6 @@
 package sh.jmx.jmxsh.cmd;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -57,11 +56,7 @@ public class RunCommand extends Command {
               .getServerConnection()
               .getMBeanInfo(new ObjectName(session.getBean()));
       MBeanOperationInfo[] operationInfos = info.getOperations();
-      List<String> ops = new ArrayList<>(operationInfos.length);
-      for (MBeanOperationInfo op : operationInfos) {
-        ops.add(op.getName());
-      }
-      return ops;
+      return Arrays.stream(operationInfos).map(MBeanOperationInfo::getName).toList();
     }
     return null;
   }
@@ -158,11 +153,11 @@ public class RunCommand extends Command {
     // Invoke operation, record execution time if measure flag is on
     Object result;
     if (measure) {
-      long start = System.currentTimeMillis();
+      long start = System.nanoTime();
       try {
         result = con.invoke(name, operationName, params, signatures);
       } finally {
-        long latency = System.currentTimeMillis() - start;
+        long latency = (System.nanoTime() - start) / 1_000_000;
         session.getOutput().printMessage(latency + "ms is taken by invocation");
       }
     } else {

--- a/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
@@ -1,7 +1,7 @@
 package sh.jmx.jmxsh.cmd;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -43,11 +43,7 @@ public class SetCommand extends Command {
       MBeanServerConnection conn = getSession().getConnection().getServerConnection();
       MBeanInfo info = conn.getMBeanInfo(new ObjectName(session.getBean()));
       MBeanAttributeInfo[] attrs = info.getAttributes();
-      List<String> attributeNames = new ArrayList<>(attrs.length);
-      for (MBeanAttributeInfo attr : attrs) {
-        attributeNames.add(attr.getName());
-      }
-      return attributeNames;
+      return Arrays.stream(attrs).map(MBeanAttributeInfo::getName).toList();
     }
     return null;
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -1,13 +1,14 @@
 package sh.jmx.jmxsh.cmd;
 
 import java.io.IOException;
-import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
@@ -89,12 +90,10 @@ public class WatchCommand extends Command {
       MBeanServerConnection con = getSession().getConnection().getServerConnection();
       MBeanAttributeInfo[] ais =
           con.getMBeanInfo(new ObjectName(getSession().getBean())).getAttributes();
-      List<String> results = new ArrayList<>(ais.length);
-      for (MBeanAttributeInfo ai : ais) {
-        results.add(ai.getName());
-      }
-      results.add(BUILDING_ATTRIBUTE_NOW);
-      return results;
+      return Stream.concat(
+              Arrays.stream(ais).map(MBeanAttributeInfo::getName),
+              Stream.of(BUILDING_ATTRIBUTE_NOW))
+          .toList();
     }
     return null;
   }
@@ -158,9 +157,9 @@ public class WatchCommand extends Command {
   private Object getAttributeValue(
       ObjectName beanName, String attributeName, MBeanServerConnection connection)
       throws IOException {
-    // $now is a reserved keyword for current java.util.Date
+    // %now is a reserved keyword for current instant
     if (BUILDING_ATTRIBUTE_NOW.equals(attributeName)) {
-      return new Date();
+      return Instant.now();
     }
     try {
       return connection.getAttribute(beanName, attributeName);
@@ -190,7 +189,7 @@ public class WatchCommand extends Command {
       for (String attributeNamne : attributes) {
         values[i++] = getAttributeValue(beanName, attributeNamne, connection);
       }
-      result = new MessageFormat(outputFormat).format(values);
+      result = outputFormat.formatted(values);
     }
     output.printLine(result);
   }
@@ -201,11 +200,11 @@ public class WatchCommand extends Command {
     this.attributes = attributes;
   }
 
-  /** @param outputFormat Pattern used in {@link MessageFormat} */
+  /** @param outputFormat printf-style format string to print attribute values */
   @Option(
       names = {"-f", "--format"},
       paramLabel = "expr",
-      description = "Java pattern(java.text.MessageFormat) to print attribute values")
+      description = "printf-style format string (e.g. '%s %s') to print attribute values")
   public final void setOutputFormat(String outputFormat) {
     this.outputFormat = outputFormat;
   }

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandInput.java
@@ -1,10 +1,10 @@
 package sh.jmx.jmxsh.io;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 
 /**
@@ -20,9 +20,9 @@ public class FileCommandInput extends CommandInput {
    * @param inputFile Given input file
    * @throws IOException Thrown when file doesn't exist or can't be read
    */
-  public FileCommandInput(File inputFile) throws IOException {
+  public FileCommandInput(Path inputFile) throws IOException {
     Objects.requireNonNull(inputFile, "Input can't be NULL");
-    this.in = new LineNumberReader(Files.newBufferedReader(inputFile.toPath(), StandardCharsets.UTF_8));
+    this.in = new LineNumberReader(Files.newBufferedReader(inputFile, StandardCharsets.UTF_8));
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
@@ -1,10 +1,10 @@
 package sh.jmx.jmxsh.io;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 import java.util.Objects;
@@ -23,18 +23,16 @@ public class FileCommandOutput extends CommandOutput {
    * @param appendToOutput whether to write to output.
    * @throws IOException allows IO error.
    */
-  public FileCommandOutput(File file, boolean appendToOutput) throws IOException {
+  public FileCommandOutput(Path file, boolean appendToOutput) throws IOException {
     Objects.requireNonNull(file, "File can't be NULL");
-    File af = file.getAbsoluteFile();
-    if (!af.getParentFile().isDirectory() && !af.getParentFile().mkdirs()) {
-        throw new IOException("Couldn't make directory " + af.getParentFile());
-      }
+    Path af = file.toAbsolutePath();
+    Files.createDirectories(af.getParent());
 
     var openOptions = appendToOutput
         ? new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.APPEND}
         : new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING};
     fileWriter = new PrintWriter(
-        Files.newBufferedWriter(af.toPath(), StandardCharsets.UTF_8, openOptions));
+        Files.newBufferedWriter(af, StandardCharsets.UTF_8, openOptions));
     output = new WriterCommandOutput(fileWriter, new PrintWriter(System.err, true));
   }
 

--- a/src/main/java/sh/jmx/jmxsh/io/InputStreamCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/InputStreamCommandInput.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -16,7 +17,7 @@ public class InputStreamCommandInput extends CommandInput {
   /** @param in Given input stream */
   public InputStreamCommandInput(InputStream in) {
     Objects.requireNonNull(in, "Input stream can't be NULL");
-    reader = new LineNumberReader(new InputStreamReader(in));
+    reader = new LineNumberReader(new InputStreamReader(in, StandardCharsets.UTF_8));
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
@@ -5,7 +5,6 @@ package sh.jmx.jmxsh.utils;
  * attribute value or parameter of operation. It's NOT designed to parse MBean name or other type of
  * input.
  *
- * @version $Revision$ in $Change$ submitted at $DateTime$
  */
 public final class ValueFormat {
   /** Keyword that identifies NULL pointer <code>null</code> */

--- a/src/test/java/sh/jmx/jmxsh/cc/ConnectionImplTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/ConnectionImplTest.java
@@ -26,7 +26,7 @@ class ConnectionImplTest {
   void construction() throws Exception {
     JMXConnector con = mock(JMXConnector.class);
     ConnectionImpl c = new ConnectionImpl(con, SyntaxUtils.getUrl("localhost:9991", null));
-    assertThat(c.getConnector()).isSameAs(con);
+    assertThat(c.connector()).isSameAs(con);
 
     when(con.getConnectionId()).thenReturn("xyz");
     assertThat(c.getConnectorId()).isEqualTo("xyz");

--- a/src/test/java/sh/jmx/jmxsh/e2e/CliArgumentsE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/CliArgumentsE2EIT.java
@@ -29,8 +29,8 @@ class CliArgumentsE2EIT {
 
   @Test
   void testAutoConnect() throws Exception {
-    try (JmxTermProcessHelper jmxterm =
-        new JmxTermProcessHelper("-l", "localhost:" + targetJvm.getJmxPort())) {
+    try (JmxshProcessHelper jmxterm =
+        new JmxshProcessHelper("-l", "localhost:" + targetJvm.getJmxPort())) {
       jmxterm.sendCommandAndClose("domains", "quit");
       String output = jmxterm.readAllOutput(TIMEOUT);
       assertThat(output)
@@ -41,7 +41,7 @@ class CliArgumentsE2EIT {
 
   @Test
   void testSilentMode() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-q")) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper("-q")) {
       jmxterm.sendCommandAndClose(
           "open localhost:" + targetJvm.getJmxPort(),
           "bean test:type=TestMBean",
@@ -61,7 +61,7 @@ class CliArgumentsE2EIT {
 
   @Test
   void testExitOnFailure() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-e")) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper("-e")) {
       // Send a command that fails (getting an attribute without a connection)
       jmxterm.sendCommandAndClose("get Name");
       String output = jmxterm.readAllOutput(TIMEOUT);
@@ -72,7 +72,7 @@ class CliArgumentsE2EIT {
 
   @Test
   void testHelpFlag() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-h")) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper("-h")) {
       String output = jmxterm.readAllOutput(TIMEOUT);
       int exitCode = jmxterm.getExitCode();
       assertThat(output)

--- a/src/test/java/sh/jmx/jmxsh/e2e/ExitCodeE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/ExitCodeE2EIT.java
@@ -29,7 +29,7 @@ class ExitCodeE2EIT {
 
   @Test
   void testSuccessfulExecution() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open localhost:" + targetJvm.getJmxPort(), "domains", "quit");
       jmxterm.readAllOutput(TIMEOUT);
@@ -39,7 +39,7 @@ class ExitCodeE2EIT {
 
   @Test
   void testExitOnFailureReturnsNegativeLineNumber() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-e")) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper("-e")) {
       // Line 1: valid command (help), Line 2: invalid command (get without connection/bean)
       jmxterm.sendCommandAndClose("help", "get Name");
       jmxterm.readAllOutput(TIMEOUT);
@@ -56,7 +56,7 @@ class ExitCodeE2EIT {
 
   @Test
   void testQuitExitCode() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose("quit");
       jmxterm.readAllOutput(TIMEOUT);
       assertThat(jmxterm.getExitCode()).as("Quit command should return exit code 0").isEqualTo(0);

--- a/src/test/java/sh/jmx/jmxsh/e2e/JmxmpConnectionE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/JmxmpConnectionE2EIT.java
@@ -32,7 +32,7 @@ class JmxmpConnectionE2EIT {
 
   @Test
   void testOpenWithJmxmpShorthand() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open jmxmp://localhost:" + targetJvm.getJmxmpPort(), "domains", "quit");
       String output = jmxterm.readAllOutput(TIMEOUT);
@@ -44,7 +44,7 @@ class JmxmpConnectionE2EIT {
 
   @Test
   void testOpenWithFullJmxmpServiceUrl() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open service:jmx:jmxmp://localhost:" + targetJvm.getJmxmpPort(), "domains", "quit");
       String output = jmxterm.readAllOutput(TIMEOUT);
@@ -56,7 +56,7 @@ class JmxmpConnectionE2EIT {
 
   @Test
   void testGetAttributeOverJmxmp() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open jmxmp://localhost:" + targetJvm.getJmxmpPort(),
           "bean test:type=TestMBean",
@@ -70,7 +70,7 @@ class JmxmpConnectionE2EIT {
 
   @Test
   void testRunOperationOverJmxmp() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open jmxmp://localhost:" + targetJvm.getJmxmpPort(),
           "bean test:type=TestMBean",

--- a/src/test/java/sh/jmx/jmxsh/e2e/JmxshProcessHelper.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/JmxshProcessHelper.java
@@ -13,21 +13,21 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Launches the jmxterm uber JAR as a subprocess in non-interactive mode and provides methods to
+ * Launches the jmxsh uber JAR as a subprocess in non-interactive mode and provides methods to
  * send commands via stdin and read output from stdout.
  */
-public class JmxTermProcessHelper implements AutoCloseable {
+public class JmxshProcessHelper implements AutoCloseable {
 
   private final Process process;
 
   /**
-   * Finds the uber JAR and launches jmxterm with {@code -n} (non-interactive) plus any extra
+   * Finds the uber JAR and launches jmxsh with {@code -n} (non-interactive) plus any extra
    * arguments.
    *
    * @param extraArgs additional CLI arguments (e.g. {@code "-q"} for quiet mode)
    * @throws IOException if the JAR is not found or the process cannot be started
    */
-  public JmxTermProcessHelper(String... extraArgs) throws IOException {
+  public JmxshProcessHelper(String... extraArgs) throws IOException {
     Path uberJar = findUberJar();
     String javaHome = System.getProperty("java.home");
     String javaBin = javaHome + "/bin/java";
@@ -96,7 +96,7 @@ public class JmxTermProcessHelper implements AutoCloseable {
       exited = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new IllegalStateException("Interrupted while waiting for jmxterm to exit", e);
+      throw new IllegalStateException("Interrupted while waiting for jmxsh to exit", e);
     }
 
     String line;
@@ -107,13 +107,13 @@ public class JmxTermProcessHelper implements AutoCloseable {
     if (!exited) {
       process.destroyForcibly();
       throw new IllegalStateException(
-          "jmxterm did not exit within " + timeout.toSeconds() + " seconds");
+          "jmxsh did not exit within " + timeout.toSeconds() + " seconds");
     }
     return sb.toString();
   }
 
   /**
-   * Returns the exit code of the jmxterm process. The process must have already exited.
+   * Returns the exit code of the jmxsh process. The process must have already exited.
    *
    * @return the exit code
    */

--- a/src/test/java/sh/jmx/jmxsh/e2e/ScriptExecutionE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/ScriptExecutionE2EIT.java
@@ -32,7 +32,7 @@ class ScriptExecutionE2EIT {
 
   @Test
   void testBasicCommandExecution() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open localhost:" + targetJvm.getJmxPort(), "domains", "quit");
       String output = jmxterm.readAllOutput(TIMEOUT);
@@ -45,7 +45,7 @@ class ScriptExecutionE2EIT {
 
   @Test
   void testGetAttribute() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open localhost:" + targetJvm.getJmxPort(),
           "bean test:type=TestMBean",
@@ -59,7 +59,7 @@ class ScriptExecutionE2EIT {
 
   @Test
   void testSetAndGetAttribute() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open localhost:" + targetJvm.getJmxPort(),
           "bean test:type=TestMBean",
@@ -73,7 +73,7 @@ class ScriptExecutionE2EIT {
 
   @Test
   void testRunOperation() throws Exception {
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper()) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper()) {
       jmxterm.sendCommandAndClose(
           "open localhost:" + targetJvm.getJmxPort(),
           "bean test:type=TestMBean",

--- a/src/test/java/sh/jmx/jmxsh/e2e/StartupErrorsE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/StartupErrorsE2EIT.java
@@ -21,8 +21,8 @@ class StartupErrorsE2EIT {
    */
   @Test
   void invalidOutputFileProducesCleanError() throws Exception {
-    try (JmxTermProcessHelper jmxterm =
-        new JmxTermProcessHelper("-o", "/nonexistent/dir/output.txt")) {
+    try (JmxshProcessHelper jmxterm =
+        new JmxshProcessHelper("-o", "/nonexistent/dir/output.txt")) {
       String output = jmxterm.readAllOutput(TIMEOUT);
       int exitCode = jmxterm.getExitCode();
       assertThat(exitCode).as("Invalid output file should produce non-zero exit code").isNotEqualTo(0);
@@ -41,7 +41,7 @@ class StartupErrorsE2EIT {
   @Test
   void failedAutoConnectProducesCleanError() throws Exception {
     // Port 1 is reserved and will always refuse the connection.
-    try (JmxTermProcessHelper jmxterm = new JmxTermProcessHelper("-l", "localhost:1")) {
+    try (JmxshProcessHelper jmxterm = new JmxshProcessHelper("-l", "localhost:1")) {
       String output = jmxterm.readAllOutput(TIMEOUT);
       int exitCode = jmxterm.getExitCode();
       assertThat(exitCode).as("Failed auto-connect should produce non-zero exit code").isNotEqualTo(0);

--- a/src/test/java/sh/jmx/jmxsh/io/FileCommandInputTest.java
+++ b/src/test/java/sh/jmx/jmxsh/io/FileCommandInputTest.java
@@ -2,8 +2,8 @@ package sh.jmx.jmxsh.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +19,7 @@ class FileCommandInputTest {
    */
   @Test
   void read() throws Exception {
-    File testFile = new File("src/test/resources/testscript.jmx");
+    Path testFile = Path.of("src/test/resources/testscript.jmx");
     try(FileCommandInput input = new FileCommandInput(testFile)) {
       assertThat(input.readLine()).isEqualTo("beans");
       assertThat(input.readLine()).isEqualTo("exit");

--- a/src/test/java/sh/jmx/jmxsh/io/FileCommandOutputTest.java
+++ b/src/test/java/sh/jmx/jmxsh/io/FileCommandOutputTest.java
@@ -2,10 +2,10 @@ package sh.jmx.jmxsh.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.jupiter.api.AfterEach;
@@ -17,17 +17,14 @@ import org.junit.jupiter.api.Test;
  *
  */
 class FileCommandOutputTest {
-  private File testFile;
+  private Path testFile;
 
   /** prepare for test output file */
   @BeforeEach
   void setUpTestFile() {
-    testFile =
-        new File(
-            System.getProperty("java.io.tmpdir")
-                + "/test-"
-                + randomAlphabetic(20)
-                + ".txt");
+    testFile = Path.of(
+        System.getProperty("java.io.tmpdir"),
+        "test-" + randomAlphabetic(20) + ".txt");
   }
 
   /**
@@ -37,7 +34,7 @@ class FileCommandOutputTest {
    */
   @AfterEach
   void tearDownTestFile() throws IOException {
-    Files.deleteIfExists(testFile.toPath());
+    Files.deleteIfExists(testFile);
   }
 
   /**
@@ -52,7 +49,7 @@ class FileCommandOutputTest {
     output.printMessage("say hello");
     output.close();
 
-    assertThat(Files.readString(testFile.toPath(), StandardCharsets.UTF_8).trim())
+    assertThat(Files.readString(testFile, StandardCharsets.UTF_8).trim())
         .isEqualTo("helloworld");
   }
 
@@ -73,7 +70,7 @@ class FileCommandOutputTest {
     output2.printMessage("say hello2");
     output2.close();
 
-    assertThat(Files.readString(testFile.toPath(), StandardCharsets.UTF_8).trim())
+    assertThat(Files.readString(testFile, StandardCharsets.UTF_8).trim())
         .isEqualTo("helloworld" + System.lineSeparator() + "helloworld2");
   }
 


### PR DESCRIPTION
## Summary

Cleans up legacy code patterns identified in the `## Legacy` section of TODO.md.

## Changes

### Dependencies
- Remove `jcl-over-slf4j` (no transitive dependency on commons-logging confirmed)

### Fork vestiges
- Rename picocli command `jmxterm` → `jmxsh` and fix descriptions in `CliMainOptions`
- Rename `JmxTermProcessHelper` → `JmxshProcessHelper` and update all 5 E2E test files

### Spelling fix
- Rename `ConsoleCompletor` → `ConsoleCompleter` (JLine 3+ spelling)

### Legacy Java APIs
- Remove SVN/CVS keyword placeholders from `ValueFormat` Javadoc
- Replace `java.util.Date` with `Instant` in `WatchCommand`
- Replace `java.io.File` with `Path` in `FileCommandInput`, `FileCommandOutput`, `CliMain`, `CliMainOptions`
- Add `StandardCharsets.UTF_8` to `InputStreamCommandInput`
- Replace `java.io.IOError` with `UncheckedIOException` in `Session`
- Replace `System.currentTimeMillis()` with `nanoTime` in `RunCommand`
- Replace `MessageFormat` with `.formatted()` in `WatchCommand` (format option now uses printf syntax)

### Modern language constructs
- Convert old-style `switch` to arrow-switch in `InfoCommand`
- Replace manual for-loops with streams in `RunCommand`, `GetCommand`, `SetCommand`, `WatchCommand`
- Replace `String.format()` with `.formatted()` in `InfoCommand`
- Replace `toArray(new String[0])` with `toArray(String[]::new)` in `CommandCenter`
- Replace `.indexOf() != -1` with `.contains()` in `CommandCenter`, `BeanCommand`

### Records
- Convert `ConnectionImpl` to a record, removing Lombok annotations

### TODO.md
- Remove all fixed bullet points
- Keep: JMXMP bullet removed (per user request), `.jmxterm_history` migration bullet removed (kept forever)

## Breaking change
The `-f/--format` option in the `watch` command now uses **printf syntax** (e.g. `%s %1$s`) instead of `MessageFormat` syntax (`{0} {1}`).