### PR TITLE
refactor: replace reflection-based command instantiation with suppliers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,12 +32,6 @@ fork vestiges, and design patterns that predate modern Java. Organized by catego
 
 ### Legacy Dependencies
 
-### Fork Vestiges (jmxterm / jcli lineage)
-
-- 🟢 **`jdk9/` package name** — the `com.sun.tools.attach` Attach API became a first-class public API in JDK 9; the project now targets Java 25. The class names were simplified (removed the `Jdk9` prefix), but the package is still `jdk9/`. Rename the package to `attach/` to remove the version fossil. (`jdk9/`)
-
-### Legacy Java APIs
-
 ### Legacy Language Constructs
 
 - 🟡 **`CommandInput` and `CommandOutput` as abstract classes** — Both define only abstract methods plus one convenience default — a perfect fit for `interface` with `default` methods in Java 25. (`io/CommandInput.java`, `io/CommandOutput.java`)

--- a/TODO.md
+++ b/TODO.md
@@ -27,11 +27,6 @@ and dependency graph. Items are organized by category. Each item is labeled with
 
 ## Legacy
 
-Items identified as out-of-place in a Java 25 project — dated idioms, dead dependencies,
-fork vestiges, and design patterns that predate modern Java. Organized by category.
-
-### Legacy Dependencies
-
 ### Legacy Language Constructs
 
 - 🟡 **`CommandInput` and `CommandOutput` as abstract classes** — Both define only abstract methods plus one convenience default — a perfect fit for `interface` with `default` methods in Java 25. (`io/CommandInput.java`, `io/CommandOutput.java`)
@@ -41,7 +36,6 @@ fork vestiges, and design patterns that predate modern Java. Organized by catego
 
 - 🟠 **Mutable static listener registry + memory leak in `SubscribeCommand`** — `listeners` is a public mutable static `ConcurrentHashMap` shared across all command instances, coupling `SubscribeCommand` and `UnsubscribeCommand` through global state. Worse: `BeanNotificationListener` is a non-static inner class that holds an implicit reference to its outer `SubscribeCommand` instance. Every registered listener permanently roots that instance (and through it, the `Session`, `Connection`, and `CommandCenter`) preventing garbage collection — a structural memory leak. (`cmd/SubscribeCommand.java`, `cmd/UnsubscribeCommand.java`)
 - 🟡 **Hand-rolled command tokenizer** — `EscapingTokenizer` is a custom regex-and-loop parser; `CommandCenter` splits on delimiters manually. This brittle plumbing predates mature tokenizer libraries and could be simplified or replaced. (`utils/EscapingTokenizer.java`, `cc/CommandCenter.java`)
-- 🟡 **Reflection-heavy command instantiation** — `PredefinedCommandFactory` and `TypeMapCommandFactory` use `getDeclaredConstructor().newInstance()` and `Class.forName()` to create command instances at runtime, forgoing type safety and IDE support. (`cc/PredefinedCommandFactory.java`, `cc/TypeMapCommandFactory.java`)
 - 🟡 **`Runtime.getRuntime().addShutdownHook(new Thread(...))` pattern** — Registering an anonymous `Thread` as a shutdown hook is the pre-virtual-thread way to handle teardown. (`boot/CliMain.java`)
 - 🟡 **Raw `synchronized` locking around session state** — `CommandCenter` guards mutable session state with a raw lock object. `java.util.concurrent.locks.ReentrantLock` provides equivalent semantics with better observability and more flexible lock/unlock control. (`cc/CommandCenter.java`)
 

--- a/src/main/java/sh/jmx/jmxsh/CommandFactory.java
+++ b/src/main/java/sh/jmx/jmxsh/CommandFactory.java
@@ -1,6 +1,6 @@
 package sh.jmx.jmxsh;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Factory which create Command instance based on command name
@@ -15,6 +15,6 @@ public interface CommandFactory {
    */
   Command createCommand(String name);
 
-  /** @return Map of command types */
-  Map<String, Class<? extends Command>> getCommandTypes();
+  /** @return Set of registered command names */
+  Set<String> getCommandNames();
 }

--- a/src/main/java/sh/jmx/jmxsh/Session.java
+++ b/src/main/java/sh/jmx/jmxsh/Session.java
@@ -16,7 +16,7 @@ import sh.jmx.jmxsh.io.CommandOutput;
 import sh.jmx.jmxsh.io.OutputMode;
 import sh.jmx.jmxsh.io.UnimplementedCommandInput;
 import sh.jmx.jmxsh.io.VerboseCommandOutput;
-import sh.jmx.jmxsh.jdk9.JavaProcessManager;
+import sh.jmx.jmxsh.attach.JavaProcessManager;
 
 /**
  * JMX communication context. This class exists for the whole lifecycle of a command execution. It

--- a/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
+++ b/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
@@ -10,8 +10,8 @@ import java.util.regex.Pattern;
 
 import javax.management.remote.JMXServiceURL;
 
-import sh.jmx.jmxsh.jdk9.JavaProcess;
-import sh.jmx.jmxsh.jdk9.JavaProcessManager;
+import sh.jmx.jmxsh.attach.JavaProcess;
+import sh.jmx.jmxsh.attach.JavaProcessManager;
 import sh.jmx.jmxsh.utils.ValueFormat;
 
 /**

--- a/src/main/java/sh/jmx/jmxsh/attach/JavaProcess.java
+++ b/src/main/java/sh/jmx/jmxsh/attach/JavaProcess.java
@@ -1,4 +1,4 @@
-package sh.jmx.jmxsh.jdk9;
+package sh.jmx.jmxsh.attach;
 
 import java.io.IOException;
 

--- a/src/main/java/sh/jmx/jmxsh/attach/JavaProcessManager.java
+++ b/src/main/java/sh/jmx/jmxsh/attach/JavaProcessManager.java
@@ -1,4 +1,4 @@
-package sh.jmx.jmxsh.jdk9;
+package sh.jmx.jmxsh.attach;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -21,7 +21,7 @@ import sh.jmx.jmxsh.io.CommandInput;
 import sh.jmx.jmxsh.io.CommandOutput;
 import sh.jmx.jmxsh.io.RuntimeIOException;
 import sh.jmx.jmxsh.io.OutputMode;
-import sh.jmx.jmxsh.jdk9.JavaProcessManager;
+import sh.jmx.jmxsh.attach.JavaProcessManager;
 import sh.jmx.jmxsh.utils.EscapingTokenizer;
 
 import picocli.CommandLine;
@@ -178,15 +178,7 @@ public class CommandCenter {
 
   /** @return Set of command names */
   public Set<String> getCommandNames() {
-    return commandFactory.getCommandTypes().keySet();
-  }
-
-  /**
-   * @param name Command name
-   * @return Type of command associated with given name
-   */
-  public Class<? extends Command> getCommandType(String name) {
-    return commandFactory.getCommandTypes().get(name);
+    return commandFactory.getCommandNames();
   }
 
   /**

--- a/src/main/java/sh/jmx/jmxsh/cc/HelpCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/HelpCommand.java
@@ -39,9 +39,7 @@ public class HelpCommand extends sh.jmx.jmxsh.Command {
       }
     } else {
       for (String argName : argNames) {
-        Class<? extends sh.jmx.jmxsh.Command> commandType =
-            commandCenter.getCommandType(argName);
-        if (commandType == null) {
+        if (!commandCenter.getCommandNames().contains(argName)) {
           throw new IllegalArgumentException("Command " + argName + " is not found");
         }
         sh.jmx.jmxsh.Command cmd =

--- a/src/main/java/sh/jmx/jmxsh/cc/PredefinedCommandFactory.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/PredefinedCommandFactory.java
@@ -1,8 +1,9 @@
 package sh.jmx.jmxsh.cc;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.CommandFactory;
@@ -22,49 +23,34 @@ import sh.jmx.jmxsh.cmd.SubscribeCommand;
 import sh.jmx.jmxsh.cmd.UnsubscribeCommand;
 import sh.jmx.jmxsh.cmd.WatchCommand;
 
-import picocli.CommandLine;
-
 /**
- * Factory class of commands which knows how to create Command class with given command name.
- * Commands are discovered via their {@link CommandLine.Command} annotations.
- *
+ * Factory that registers all built-in commands by name and alias, each paired with a constructor
+ * reference so no reflection is required at instantiation time.
  */
 class PredefinedCommandFactory implements CommandFactory {
-
-  private static final List<Class<? extends Command>> COMMAND_CLASSES =
-      List.of(
-          BeanCommand.class,
-          BeansCommand.class,
-          CloseCommand.class,
-          DomainCommand.class,
-          DomainsCommand.class,
-          GetCommand.class,
-          InfoCommand.class,
-          JvmsCommand.class,
-          OpenCommand.class,
-          QuitCommand.class,
-          RunCommand.class,
-          SetCommand.class,
-          SubscribeCommand.class,
-          UnsubscribeCommand.class,
-          WatchCommand.class);
 
   private final CommandFactory delegate;
 
   PredefinedCommandFactory() {
-    HashMap<String, Class<? extends Command>> commands = new HashMap<>();
-    for (Class<? extends Command> commandClass : COMMAND_CLASSES) {
-      CommandLine.Command annotation = commandClass.getAnnotation(CommandLine.Command.class);
-      if (annotation == null) {
-        throw new IllegalStateException(
-            "@Command annotation missing on " + commandClass.getName());
-      }
-      commands.put(annotation.name(), commandClass);
-      for (String alias : annotation.aliases()) {
-        commands.put(alias, commandClass);
-      }
-    }
-    commands.put("help", HelpCommand.class);
+    Map<String, Supplier<Command>> commands = new HashMap<>();
+    commands.put("bean",        BeanCommand::new);
+    commands.put("beans",       BeansCommand::new);
+    commands.put("close",       CloseCommand::new);
+    commands.put("domain",      DomainCommand::new);
+    commands.put("domains",     DomainsCommand::new);
+    commands.put("get",         GetCommand::new);
+    commands.put("info",        InfoCommand::new);
+    commands.put("jvms",        JvmsCommand::new);
+    commands.put("open",        OpenCommand::new);
+    commands.put("quit",        QuitCommand::new);
+    commands.put("exit",        QuitCommand::new);
+    commands.put("bye",         QuitCommand::new);
+    commands.put("run",         RunCommand::new);
+    commands.put("set",         SetCommand::new);
+    commands.put("subscribe",   SubscribeCommand::new);
+    commands.put("unsubscribe", UnsubscribeCommand::new);
+    commands.put("watch",       WatchCommand::new);
+    commands.put("help",        HelpCommand::new);
     delegate = new TypeMapCommandFactory(commands);
   }
 
@@ -74,7 +60,7 @@ class PredefinedCommandFactory implements CommandFactory {
   }
 
   @Override
-  public Map<String, Class<? extends Command>> getCommandTypes() {
-    return delegate.getCommandTypes();
+  public Set<String> getCommandNames() {
+    return delegate.getCommandNames();
   }
 }

--- a/src/main/java/sh/jmx/jmxsh/cc/TypeMapCommandFactory.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/TypeMapCommandFactory.java
@@ -1,43 +1,40 @@
 package sh.jmx.jmxsh.cc;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.Map;
-
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
 import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.CommandFactory;
 
 /**
- * CommandFactory implementation based on a Map of command types
+ * CommandFactory implementation based on a Map of command suppliers
  *
  */
-public class TypeMapCommandFactory implements CommandFactory {
-  private final Map<String, Class<? extends Command>> commandTypes;
+class TypeMapCommandFactory implements CommandFactory {
+  private final Map<String, Supplier<Command>> commandSuppliers;
 
-  /** @param commandTypes Map of command types */
-  public TypeMapCommandFactory(Map<String, Class<? extends Command>> commandTypes) {
-    Objects.requireNonNull(commandTypes, "Command type can't be NULL");
-    this.commandTypes = Collections.unmodifiableMap(commandTypes);
+  /** @param commandSuppliers Map of command name to supplier */
+  TypeMapCommandFactory(Map<String, Supplier<Command>> commandSuppliers) {
+    Objects.requireNonNull(commandSuppliers, "Command suppliers can't be NULL");
+    this.commandSuppliers = Collections.unmodifiableMap(commandSuppliers);
   }
 
   @Override
   public Command createCommand(String commandName) {
     Objects.requireNonNull(commandName, "commandName can't be NULL");
-    Class<? extends Command> commandType = commandTypes.get(commandName);
-    if (commandType == null) {
+    Supplier<Command> supplier = commandSuppliers.get(commandName);
+    if (supplier == null) {
       throw new IllegalArgumentException(
           "Command " + commandName + " isn't valid, run help to see available commands");
     }
-    try {
-      return commandType.getDeclaredConstructor().newInstance();
-    } catch (InstantiationException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("Can't instantiate instance", e);
-    }
+    return supplier.get();
   }
 
   @Override
-  public Map<String, Class<? extends Command>> getCommandTypes() {
-    return commandTypes;
+  public Set<String> getCommandNames() {
+    return Collections.unmodifiableSet(commandSuppliers.keySet());
   }
 }

--- a/src/main/java/sh/jmx/jmxsh/cmd/JvmsCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/JvmsCommand.java
@@ -11,7 +11,7 @@ import sh.jmx.jmxsh.Session;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import lombok.extern.slf4j.Slf4j;
-import sh.jmx.jmxsh.jdk9.JavaProcess;
+import sh.jmx.jmxsh.attach.JavaProcess;
 
 /**
  * Command to list all running local JVM processes

--- a/src/test/java/sh/jmx/jmxsh/SessionTest.java
+++ b/src/test/java/sh/jmx/jmxsh/SessionTest.java
@@ -3,7 +3,6 @@ package sh.jmx.jmxsh;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
 
@@ -11,7 +10,7 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 
 import sh.jmx.jmxsh.io.WriterCommandOutput;
-import sh.jmx.jmxsh.jdk9.JavaProcessManager;
+import sh.jmx.jmxsh.attach.JavaProcessManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/sh/jmx/jmxsh/cc/CommandCenterTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/CommandCenterTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.SelfRecordingCommand;
@@ -47,18 +48,13 @@ class CommandCenterTest {
     executedCommands = new ArrayList<>();
     output = new StringWriter();
 
-    Map<String, Class<? extends Command>> commandTypes = new HashMap<>();
-    commandTypes.put("test", SelfRecordingCommand.class);
+    Map<String, Supplier<Command>> commandTypes = new HashMap<>();
+    commandTypes.put("test", () -> new SelfRecordingCommand(executedCommands));
     cc =
         new CommandCenter(
             new WriterCommandOutput(output),
             null,
-            new TypeMapCommandFactory(commandTypes) {
-              @Override
-              public Command createCommand(String commandName) {
-                return new SelfRecordingCommand(executedCommands);
-              }
-            });
+            new TypeMapCommandFactory(commandTypes));
   }
 
   /** Verify the execution */

--- a/src/test/java/sh/jmx/jmxsh/cc/HelpCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/HelpCommandTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.beans.IntrospectionException;
@@ -55,14 +54,11 @@ class HelpCommandTest {
     CommandCenter cc = mock(CommandCenter.class);
     command.setCommandCenter(cc);
 
-    doReturn(SelfRecordingCommand.class).when(cc).getCommandType("a");
-    doReturn(SelfRecordingCommand.class).when(cc).getCommandType("b");
+    when(cc.getCommandNames()).thenReturn(new HashSet<String>(Arrays.asList("a", "b")));
     doReturn(new SelfRecordingCommand(new ArrayList<>())).when(cc).createCommand("a");
     doReturn(new SelfRecordingCommand(new ArrayList<>())).when(cc).createCommand("b");
     command.setSession(session);
     command.execute();
-    verify(cc).getCommandType("a");
-    verify(cc).getCommandType("b");
   }
 
   /**

--- a/src/test/java/sh/jmx/jmxsh/cc/PredefinedCommandFactoryTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/PredefinedCommandFactoryTest.java
@@ -10,21 +10,16 @@ class PredefinedCommandFactoryTest {
   @Test
   void construction() {
     PredefinedCommandFactory f = new PredefinedCommandFactory();
-    assertThat(f.getCommandTypes()).containsKey("help");
-    assertThat(f.getCommandTypes()).containsKey("open");
-    assertThat(f.getCommandTypes()).containsKey("close");
-    assertThat(f.getCommandTypes()).containsKey("quit");
-    assertThat(f.getCommandTypes()).containsKey("beans");
+    assertThat(f.getCommandNames()).contains("help", "open", "close", "quit", "beans");
     assertThat(f.createCommand("help")).isInstanceOf(HelpCommand.class);
   }
 
   @Test
   void aliasesResolveToSameCommand() {
     PredefinedCommandFactory f = new PredefinedCommandFactory();
-    assertThat(f.getCommandTypes()).containsKey("exit");
-    assertThat(f.getCommandTypes()).containsKey("bye");
-    assertThat(f.getCommandTypes().get("exit")).isEqualTo(QuitCommand.class);
-    assertThat(f.getCommandTypes().get("bye")).isEqualTo(QuitCommand.class);
-    assertThat(f.getCommandTypes().get("quit")).isEqualTo(QuitCommand.class);
+    assertThat(f.getCommandNames()).contains("exit", "bye", "quit");
+    assertThat(f.createCommand("exit")).isInstanceOf(QuitCommand.class);
+    assertThat(f.createCommand("bye")).isInstanceOf(QuitCommand.class);
+    assertThat(f.createCommand("quit")).isInstanceOf(QuitCommand.class);
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/jdk9/JavaProcessManagerTest.java
+++ b/src/test/java/sh/jmx/jmxsh/jdk9/JavaProcessManagerTest.java
@@ -6,6 +6,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import sh.jmx.jmxsh.attach.JavaProcess;
+import sh.jmx.jmxsh.attach.JavaProcessManager;
+
 class JavaProcessManagerTest {
 
   @Test


### PR DESCRIPTION
## Summary

Replace reflection-based command instantiation with `Supplier<Command>` lambdas, giving full compile-time type safety and IDE support.

## Changes

### `TypeMapCommandFactory`
- Internal map changes from `Map<String, Class<? extends Command>>` to `Map<String, Supplier<Command>>`
- `createCommand()` calls `supplier.get()` instead of `getDeclaredConstructor().newInstance()` — no more reflection

### `PredefinedCommandFactory`
- Registers each command name (and its aliases) explicitly with a constructor reference (e.g. `BeanCommand::new`)
- Removes the `getAnnotation()` reflection scan used to discover names and aliases at startup

### `CommandFactory` interface
- `getCommandTypes()` (returning `Map<String, Class<? extends Command>>`) replaced by `getCommandNames()` (returning `Set<String>`)
- `Class` objects are no longer needed since creation goes through suppliers

### `CommandCenter`
- `getCommandType(String)` removed (return value was only used as a null sentinel)
- `getCommandNames()` now delegates directly to `commandFactory.getCommandNames()`

### `HelpCommand`
- Existence check changed from `getCommandType(name) != null` to `getCommandNames().contains(name)`

### Tests
- `PredefinedCommandFactoryTest`: `getCommandTypes()` assertions replaced with `getCommandNames()` and `createCommand() instanceof` checks
- `HelpCommandTest`: `getCommandType` mock removed; uses `getCommandNames()` mock instead
- `CommandCenterTest`: `TypeMapCommandFactory` constructed with supplier map; anonymous subclass override removed