### PR TITLE
refactor: convert CommandInput/Output to interfaces, simplify WatchCommand

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,11 +26,6 @@ and dependency graph. Items are organized by category. Each item is labeled with
 
 ## Legacy
 
-### Legacy Language Constructs
-
-- 🟡 **`CommandInput` and `CommandOutput` as abstract classes** — Both define only abstract methods plus one convenience default — a perfect fit for `interface` with `default` methods in Java 25. (`io/CommandInput.java`, `io/CommandOutput.java`)
-- 🟡 **`WatchCommand` three-class hierarchy for a single-method abstraction** — The `Output` / `ConsoleOutput` / `ReportOutput` class hierarchy exists to abstract a single `printLine(String)` call. A `@FunctionalInterface` (or a lambda) collapses this to one line. (`cmd/WatchCommand.java`)
-
 ### Legacy Architecture
 
 - 🟠 **Mutable static listener registry + memory leak in `SubscribeCommand`** — `listeners` is a public mutable static `ConcurrentHashMap` shared across all command instances, coupling `SubscribeCommand` and `UnsubscribeCommand` through global state. Worse: `BeanNotificationListener` is a non-static inner class that holds an implicit reference to its outer `SubscribeCommand` instance. Every registered listener permanently roots that instance (and through it, the `Session`, `Connection`, and `CommandCenter`) preventing garbage collection — a structural memory leak. (`cmd/SubscribeCommand.java`, `cmd/UnsubscribeCommand.java`)

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -145,14 +145,14 @@ The standard JMX interface (`javax.management.MBeanServerConnection`) obtained f
 
 Abstractions for input and output (`sh.jmx.jmxsh.io`):
 
-- **CommandInput** — reads user commands. Implementations: `JlineCommandInput` (interactive console
-  with tab completion and history), `FileCommandInput` (script files), `InputStreamCommandInput`
-  (piped input)
-- **CommandOutput** — writes results and messages. `VerboseCommandOutput` is a decorator that
-  filters output based on `OutputMode` (SILENT or BRIEF)
+- **CommandInput** — interface for reading user commands. Implementations: `JlineCommandInput`
+  (interactive console with tab completion and history), `FileCommandInput` (script files),
+  `InputStreamCommandInput` (piped input)
+- **CommandOutput** — interface for writing results and messages. `VerboseCommandOutput` is a
+  decorator that filters output based on `OutputMode` (SILENT or BRIEF)
 
 ### JavaProcessManager
 
 Discovers local JVM processes for the `jvms` command and PID-based `open` connections
-(`sh.jmx.jmxsh.jdk9.JavaProcessManager`). Uses the `VirtualMachine` Attach API to list
+(`sh.jmx.jmxsh.attach.JavaProcessManager`). Uses the `VirtualMachine` Attach API to list
 running JVMs and can attach a JMX management agent to a process by PID.

--- a/src/main/java/sh/jmx/jmxsh/Command.java
+++ b/src/main/java/sh/jmx/jmxsh/Command.java
@@ -22,55 +22,29 @@ public abstract class Command implements Completable {
 
   private Session session;
 
-  /**
-   * Provide a list of possible arguments for auto completion. This method returns list of
-   * arguments(not option) and is called when user presses tab key.
-   *
-   * @return List of possible arguments used by auto completion or NULL
-   * @throws IOException IO errors
-   * @throws JMException JMX problemo
-   */
   protected List<String> doSuggestArgument() throws IOException, JMException {
     return null;
   }
 
-  /**
-   * Provide a list of possible option values for auto completion
-   *
-   * @param optionName Name of option
-   * @return List of possible arguments used by auto completion or NULL
-   * @throws IOException Network communication errors
-   * @throws JMException JMX errors
-   */
   protected List<String> doSuggestOption(String optionName) throws IOException, JMException {
     return null;
   }
 
-  /**
-   * Execute command
-   *
-   * @throws IOException IO errors
-   * @throws JMException JMX errors
-   */
   public abstract void execute() throws IOException, JMException;
 
-  /** @return Session where command runs */
   public final Session getSession() {
     return session;
   }
 
-  /** @return True if help option is on */
   public final boolean isHelp() {
     return help;
   }
 
-  /** @param help True to display usage */
   @Option(names = {"-h", "--help"}, usageHelp = true, description = "Display usage")
   public final void setHelp(boolean help) {
     this.help = help;
   }
 
-  /** @param session Session where command runs */
   public final void setSession(Session session) {
     Objects.requireNonNull(session, "Session can't be NULL");
     this.session = session;

--- a/src/main/java/sh/jmx/jmxsh/CommandFactory.java
+++ b/src/main/java/sh/jmx/jmxsh/CommandFactory.java
@@ -2,19 +2,8 @@ package sh.jmx.jmxsh;
 
 import java.util.Set;
 
-/**
- * Factory which create Command instance based on command name
- *
- */
 public interface CommandFactory {
-  /**
-   * Create new command instance
-   *
-   * @param name Command name
-   * @return New instance of command object
-   */
   Command createCommand(String name);
 
-  /** @return Set of registered command names */
   Set<String> getCommandNames();
 }

--- a/src/main/java/sh/jmx/jmxsh/Completable.java
+++ b/src/main/java/sh/jmx/jmxsh/Completable.java
@@ -3,25 +3,17 @@ package sh.jmx.jmxsh;
 import java.util.List;
 
 /**
- * Interface for objects that support tab completion of arguments and option values. Replaces the
- * {@code org.cyclopsgroup.jcli.AutoCompletable} interface from the JCLI library.
+ * Interface for objects that support tab completion of arguments and option values.
  */
 public interface Completable {
 
   /**
    * Suggest possible arguments for auto completion.
-   *
-   * @param partialArg Partial argument text or {@code null}
-   * @return List of possible arguments or {@code null}
    */
   List<String> suggestArgument(String partialArg);
 
   /**
    * Suggest possible option values for auto completion.
-   *
-   * @param name Option name
-   * @param partialValue Partial value text or {@code null}
-   * @return List of possible values or {@code null}
    */
   List<String> suggestOption(String name, String partialValue);
 }

--- a/src/main/java/sh/jmx/jmxsh/Session.java
+++ b/src/main/java/sh/jmx/jmxsh/Session.java
@@ -36,11 +36,6 @@ public class Session {
   private final JavaProcessManager processManager;
   private OutputMode outputMode = OutputMode.BRIEF;
 
-  /**
-   * @param output Output destination
-   * @param input Command line input
-   * @param processManager Process manager
-   */
   public Session(CommandOutput output, CommandInput input, JavaProcessManager processManager) {
     Objects.requireNonNull(output, "Output can't be NULL");
     Objects.requireNonNull(processManager, "Process manager can't be NULL");
@@ -49,7 +44,6 @@ public class Session {
     this.processManager = processManager;
   }
 
-  /** Close JMX terminal console. Supposedly, process terminates after this call */
   public void close() {
     if (closed) {
       return;
@@ -62,13 +56,6 @@ public class Session {
     closed = true;
   }
 
-  /**
-   * Connect to MBean server
-   *
-   * @param url URL to connect
-   * @param env Environment variables
-   * @throws IOException allows IO exceptions.
-   */
   public void connect(JMXServiceURL url, Map<String, Object> env) throws IOException {
     Objects.requireNonNull(url, "URL can't be NULL");
     if (connection != null) {
@@ -80,11 +67,6 @@ public class Session {
     log.info("connected to {}", url);
   }
 
-  /**
-   * Close JMX connector
-   *
-   * @throws IOException Thrown when connection can't be closed
-   */
   public void disconnect() throws IOException {
     if (connection == null) {
       return;
@@ -97,14 +79,6 @@ public class Session {
     }
   }
 
-  /**
-   * Connect to MBean server
-   *
-   * @param url MBean server URL
-   * @param env A map of environment
-   * @return Connector that holds connection to MBean server
-   * @throws IOException Network errors
-   */
   protected JMXConnector doConnect(JMXServiceURL url, Map<String, Object> env) throws IOException {
     return JMXConnectorFactory.connect(url, env);
   }
@@ -121,37 +95,24 @@ public class Session {
     return closed;
   }
 
-  /** @return True if there's a open connection to JMX server */
   public boolean isConnected() {
     return connection != null;
   }
 
-  /**
-   * Set current selected bean
-   *
-   * @param bean Bean to select
-   */
   public final void setBean(String bean) {
     this.bean = bean;
   }
 
-  /**
-   * Set current selected domain
-   *
-   * @param domain Domain to select
-   */
   public final void setDomain(String domain) {
     Objects.requireNonNull(domain, "domain can't be NULL");
     this.domain = domain;
   }
 
-  /** @param outputMode Output mode (BRIEF or SILENT) */
   public final void setOutputMode(OutputMode outputMode) {
     Objects.requireNonNull(outputMode, "Output mode can't be NULL");
     this.outputMode = outputMode;
   }
 
-  /** Set domain and bean to be NULL */
   public void unsetDomain() {
     bean = null;
     domain = null;

--- a/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
+++ b/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
@@ -14,12 +14,7 @@ import sh.jmx.jmxsh.attach.JavaProcess;
 import sh.jmx.jmxsh.attach.JavaProcessManager;
 import sh.jmx.jmxsh.utils.ValueFormat;
 
-/**
- * Utility class for syntax checking
- *
- */
 public final class SyntaxUtils {
-  /** NULL string identifier */
   public static final String NULL = ValueFormat.NULL;
 
   /** Null print stream to redirect std streams */
@@ -38,12 +33,6 @@ public final class SyntaxUtils {
       Map.entry("float", float.class),
       Map.entry("double", double.class));
 
-  /**
-   * @param url String expression of MBean server URL or abbreviation like localhost:9991
-   * @param jpm Java process manager to get process URL
-   * @return Parsed JMXServerURL
-   * @throws IOException IO error
-   */
   public static JMXServiceURL getUrl(String url, JavaProcessManager jpm) throws IOException {
     if (url == null || url.isEmpty()) {
       throw new IllegalArgumentException("Empty URL is not allowed");
@@ -70,23 +59,10 @@ public final class SyntaxUtils {
     }
   }
 
-  /**
-   * Check if string value is <code>null</code>
-   *
-   * @param s String value
-   * @return True if value is <code>null</code>
-   */
   public static boolean isNull(String s) {
     return NULL.equalsIgnoreCase(s) || "*".equals(s);
   }
 
-  /**
-   * Parse given string expression to expected type of value
-   *
-   * @param expression String expression
-   * @param type Target type
-   * @return Object of value
-   */
   public static Object parse(String expression, String type) {
     if (expression == null || NULL.equalsIgnoreCase(expression)) {
       return null;

--- a/src/main/java/sh/jmx/jmxsh/attach/JavaProcessManager.java
+++ b/src/main/java/sh/jmx/jmxsh/attach/JavaProcessManager.java
@@ -12,7 +12,6 @@ import com.sun.tools.attach.VirtualMachineDescriptor;
 
 public class JavaProcessManager {
 
-  /** Property for the local connector address */
   private static final String LOCAL_CONNECTOR_ADDRESS_PROP = "com.sun.management.jmxremote.localConnectorAddress";
 
   public JavaProcess get(int pid) {
@@ -34,7 +33,6 @@ public class JavaProcessManager {
         String address = agentProps.getProperty(LOCAL_CONNECTOR_ADDRESS_PROP);
         javaProcesses.add(new JavaProcess(vmd, address));
       } catch (AttachNotSupportedException | IOException _) {
-        // could not attach or some other exception
         javaProcesses.add(new JavaProcess(vmd, null));
       } finally {
         if (vm != null) {

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMainOptions.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMainOptions.java
@@ -9,10 +9,6 @@ import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-/**
- * Options for main class
- *
- */
 @Command(
     name = "jmxsh",
     description = "Interactive JMX shell",
@@ -27,13 +23,10 @@ import picocli.CommandLine.Option;
     })
 @Getter
 public class CliMainOptions {
-  /** Constant <code>stderr</code> that identifies standard error output */
   public static final String STDERR = "stderr";
 
-  /** Constant <code>stdin</code> that identifies standard input */
   public static final String STDIN = "stdin";
 
-  /** Constant <code>stdout</code> that identifies standard output */
   public static final String STDOUT = "stdout";
 
   private boolean exitOnFailure;
@@ -60,7 +53,6 @@ public class CliMainOptions {
 
   private boolean isSecureRmiRegistry;
 
-  /** @param exitOnFailure True if terminal exits on any failure */
   @Option(
       names = {"-e", "--exitonfailure"},
       description = "With this flag, terminal exits for any Exception")
@@ -68,7 +60,6 @@ public class CliMainOptions {
     this.exitOnFailure = exitOnFailure;
   }
 
-  /** @param file Input script path or <code>stdin</code> as default value for console input */
   @Option(
       names = {"-i", "--input"},
       description =
@@ -81,7 +72,6 @@ public class CliMainOptions {
     this.input = file;
   }
 
-  /** @param nonInteractive True if CLI runs without user interaction, such as piped input */
   @Option(
       names = {"-n", "--noninteract"},
       description =
@@ -90,7 +80,6 @@ public class CliMainOptions {
     this.nonInteractive = nonInteractive;
   }
 
-  /** @param outputFile It can be a file or {@link #STDERR} or {@link #STDERR} */
   @Option(
       names = {"-o", "--output"},
       description = "Output file, stdout or stderr. Default value is stdout")
@@ -99,7 +88,6 @@ public class CliMainOptions {
     this.output = outputFile;
   }
 
-  /** @param password Password for user/password authentication */
   @Option(
       names = {"-p", "--password"},
       description = "Password for user/password authentication")
@@ -108,7 +96,6 @@ public class CliMainOptions {
     this.password = password;
   }
 
-  /** @param url MBean server URL */
   @Option(
       names = {"-l", "--url"},
       description = "Location of MBean service. It can be <host>:<port>, jmxmp://<host>:<port>, or full service URL.")
@@ -117,14 +104,12 @@ public class CliMainOptions {
     this.url = url;
   }
 
-  /** @param user User name for user/password authentication */
   @Option(names = {"-u", "--user"}, description = "User name for user/password authentication")
   public final void setUser(String user) {
     Objects.requireNonNull(user, "User can't be NULL");
     this.user = user;
   }
 
-  /** @param quiet True to suppress all messages (silent mode) */
   @Option(
       names = {"-q", "--quiet"},
       description = "Quiet mode: suppress all messages, only output command results")
@@ -132,7 +117,6 @@ public class CliMainOptions {
     this.quiet = quiet;
   }
 
-  /** @param helpRequested True if user requested help */
   @Option(
       names = {"-h", "--help"},
       usageHelp = true,
@@ -141,7 +125,6 @@ public class CliMainOptions {
     this.helpRequested = helpRequested;
   }
 
-  /** @param versionRequested True if user requested version info */
   @Option(
       names = {"-v", "--version"},
       versionHelp = true,
@@ -150,7 +133,6 @@ public class CliMainOptions {
     this.versionRequested = versionRequested;
   }
 
-  /** @param appendToOutput True if outputfile is preserved */
   @Option(
       names = {"-a", "--appendtooutput"},
       description = "With this flag, the outputfile is preserved and content is appended to it")
@@ -158,10 +140,6 @@ public class CliMainOptions {
     this.appendToOutput = appendToOutput;
   }
 
-  /**
-   * @param isSecureRmiRegistry Whether the server's RMI registry is protected with SSL/TLS
-   *     (com.sun.management.jmxremote.registry.ssl=true)
-   */
   @Option(
       names = {"-s", "--sslrmiregistry"},
       description = "Whether the server's RMI registry is protected with SSL/TLS")

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -29,10 +29,6 @@ import org.jline.reader.impl.DefaultParser;
 import picocli.CommandLine;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Facade class where commands are maintained and executed
- *
- */
 @Slf4j
 public class CommandCenter {
   private static final DefaultParser PARSER = new DefaultParser().eofOnUnclosedQuote(true);
@@ -40,34 +36,19 @@ public class CommandCenter {
   private static final String COMMAND_DELIMITER = "&&";
   static final String ESCAPE_CHAR_REGEX = "(?<!\\\\)#";
 
-  /** Command factory that creates commands */
   final CommandFactory commandFactory;
 
   private final Lock lock = new ReentrantLock();
 
   private final JavaProcessManager processManager;
 
-  /** A handler to session */
   final Session session;
 
-  /**
-   * Constructor with given output {@link PrintWriter}
-   *
-   * @param output Message output. It can't be NULL
-   * @param input Command line input
-   * @throws IOException Thrown for file access failure
-   */
   public CommandCenter(CommandOutput output, CommandInput input) throws IOException {
     this(output, input, new PredefinedCommandFactory());
   }
 
-  /**
-   * This constructor is for testing purpose only
-   *
-   * @param output Output result
-   * @param input Command input
-   * @param commandFactory Given command factory
-   */
+  /** This constructor is for testing purpose only. */
   public CommandCenter(CommandOutput output, CommandInput input, CommandFactory commandFactory) {
     Objects.requireNonNull(output, "Output can't be NULL");
     Objects.requireNonNull(commandFactory, "Command factory can't be NULL");
@@ -76,16 +57,10 @@ public class CommandCenter {
     this.commandFactory = commandFactory;
   }
 
-  /** Close session */
   public void close() {
     session.close();
   }
 
-  /**
-   * @param url MBeanServer location. It can be <code>AAA:###</code> or full JMX server URL
-   * @param env Environment variables
-   * @throws IOException Thrown when connection can't be established
-   */
   public void connect(JMXServiceURL url, Map<String, Object> env) throws IOException {
     Objects.requireNonNull(url, "URL can't be NULL");
     session.connect(url, env);
@@ -93,21 +68,17 @@ public class CommandCenter {
 
   private void doExecute(String command) throws JMException {
     command = (command == null || command.isBlank()) ? null : command.trim();
-    // Ignore empty line
     if (command == null) {
       return;
     }
-    // Ignore line comment
     if (command.startsWith("#")) {
       return;
     }
-    // Truncate command if there's # character
     // Note: this allows people to set properties to values with # (e.g.: set AttributeA
     // /a/\\#something)
     command =
         command.split(ESCAPE_CHAR_REGEX)[0] // take out all commented out sections
             .replace("\\#", "#"); // fix escaped to non-escaped comment charaters
-    // If command includes multiple segments, call them one by one using recursive call
     if (command.contains(COMMAND_DELIMITER)) {
       String[] commands = command.split(COMMAND_DELIMITER);
       for (String c : commands) {
@@ -116,7 +87,6 @@ public class CommandCenter {
       return;
     }
 
-    // Take the first argument out since it's command name
     final List<String> args;
     try {
       args = new ArrayList<>(PARSER.parse(command, command.length(), ParseContext.ACCEPT_LINE).words());
@@ -124,9 +94,7 @@ public class CommandCenter {
       throw new IllegalArgumentException("Malformed command (check quotes): " + e.getMessage(), e);
     }
     String commandName = args.removeFirst();
-    // Leave the rest of arguments for command
     String[] commandArgs = args.toArray(String[]::new);
-    // Call command with parsed command name and arguments
     try {
       doExecute(commandName, commandArgs);
     } catch (IOException e) {
@@ -151,7 +119,6 @@ public class CommandCenter {
       session.getOutput().printMessage(sw.toString());
       return;
     }
-    // Print out usage if help option is specified
     if (cl.isUsageHelpRequested()) {
       StringWriter sw = new StringWriter();
       cl.usage(new PrintWriter(sw, true));
@@ -159,7 +126,6 @@ public class CommandCenter {
       return;
     }
     cmd.setSession(session);
-    // Make sure concurrency and run command
     lock.lock();
     try {
       cmd.execute();
@@ -168,13 +134,6 @@ public class CommandCenter {
     }
   }
 
-  /**
-   * Execute a command. Command can be a valid full command, a comment, command followed by comment
-   * or empty
-   *
-   * @param command String command to execute
-   * @return True if successful
-   */
   public boolean execute(String command) {
     try {
       doExecute(command);
@@ -185,30 +144,22 @@ public class CommandCenter {
     }
   }
 
-  /** @return Set of command names */
   public Set<String> getCommandNames() {
     return commandFactory.getCommandNames();
   }
 
-  /**
-   * @param name Command name
-   * @return A new command instance for the given name
-   */
   public Command createCommand(String name) {
     return commandFactory.createCommand(name);
   }
 
-  /** @return Java process manager implementation */
   public final JavaProcessManager getProcessManager() {
     return processManager;
   }
 
-  /** @return True if command center is closed */
   public boolean isClosed() {
     return session.isClosed();
   }
 
-  /** @param outputMode New output mode */
   public void setOutputMode(OutputMode outputMode) {
     session.setOutputMode(outputMode);
   }

--- a/src/main/java/sh/jmx/jmxsh/cc/ConsoleCompleter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/ConsoleCompleter.java
@@ -13,10 +13,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Model.OptionSpec;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * JLine completer that handles tab key
- *
- */
 @Slf4j
 public class ConsoleCompleter implements Completer {
 
@@ -53,7 +49,6 @@ public class ConsoleCompleter implements Completer {
       String currentWord = line.word();
       String previousWord = wordIndex > 1 ? words.get(wordIndex - 1) : "";
 
-      // Complete option names
       if (currentWord.startsWith("-")) {
         for (OptionSpec option : spec.options()) {
           for (String name : option.names()) {
@@ -78,7 +73,6 @@ public class ConsoleCompleter implements Completer {
         }
       }
 
-      // Complete positional arguments
       List<String> suggestions = cmd.suggestArgument(null);
       addFilteredSuggestions(suggestions, currentWord, candidates);
     } catch (RuntimeException e) {

--- a/src/main/java/sh/jmx/jmxsh/cc/HelpCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/HelpCommand.java
@@ -9,10 +9,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
-/**
- * Command that display a help message
- *
- */
 @Command(
     name = "help",
     description = "Display available commands or usage of a command",
@@ -49,14 +45,12 @@ public class HelpCommand extends sh.jmx.jmxsh.Command {
     }
   }
 
-  /** @param argNames Array of arguments */
   @Parameters(arity = "0..*")
   public final void setArgNames(List<String> argNames) {
     Objects.requireNonNull(argNames, "argNames can't be NULL");
     this.argNames = argNames;
   }
 
-  /** @param commandCenter CommandCenter object that calls this help command */
   final void setCommandCenter(CommandCenter commandCenter) {
     Objects.requireNonNull(commandCenter, "commandCenter can't be NULL");
     this.commandCenter = commandCenter;

--- a/src/main/java/sh/jmx/jmxsh/cc/TypeMapCommandFactory.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/TypeMapCommandFactory.java
@@ -16,7 +16,6 @@ import sh.jmx.jmxsh.CommandFactory;
 class TypeMapCommandFactory implements CommandFactory {
   private final Map<String, Supplier<Command>> commandSuppliers;
 
-  /** @param commandSuppliers Map of command name to supplier */
   TypeMapCommandFactory(Map<String, Supplier<Command>> commandSuppliers) {
     Objects.requireNonNull(commandSuppliers, "Command suppliers can't be NULL");
     this.commandSuppliers = Collections.unmodifiableMap(commandSuppliers);

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
@@ -21,10 +21,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Command to display or set current bean
- *
- */
 @CommandLine.Command(
     name = "bean",
     description = "Display or set current selected MBean. ",
@@ -32,16 +28,6 @@ import lombok.extern.slf4j.Slf4j;
             + "otherwise it selects the bean defined by the first parameter. eg. bean java.lang:type=Memory")
 @Slf4j
 public class BeanCommand extends Command {
-  /**
-   * Get full MBean name with given bean name, domain and session
-   *
-   * @param bean Name of bean. It can be NULL so that session#getBean() is returned
-   * @param domain Domain for bean
-   * @param session Current session
-   * @return Full qualified name of MBean
-   * @throws JMException Thrown when given MBean name is malformed
-   * @throws IOException allows IO exceptions.
-   */
   public static String getBeanName(String bean, String domain, Session session)
       throws JMException, IOException {
     Objects.requireNonNull(session, "Session can't be NULL");
@@ -75,7 +61,6 @@ public class BeanCommand extends Command {
     throw new IllegalArgumentException("Bean name " + bean + " isn't valid");
   }
 
-  /** Gets a list of candidate beans. */
   static List<String> getCandidateBeanNames(Session session) throws MalformedObjectNameException {
     try {
       ArrayList<String> results = new ArrayList<>(BeansCommand.getBeans(session, null));
@@ -134,21 +119,11 @@ public class BeanCommand extends Command {
     session.getOutput().printMessage("bean is set to " + beanName);
   }
 
-  /**
-   * Set bean option
-   *
-   * @param bean Bean to set
-   */
   @Parameters(paramLabel = "bean", description = "MBean name with or without domain", arity = "0..1")
   public final void setBean(String bean) {
     this.bean = bean;
   }
 
-  /**
-   * Set domain option
-   *
-   * @param domain Domain option to set
-   */
   @Option(names = {"-d", "--domain"}, description = "Domain name")
   public final void setDomain(String domain) {
     this.domain = domain;

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeansCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeansCommand.java
@@ -13,25 +13,12 @@ import sh.jmx.jmxsh.Session;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
-/**
- * Command that shows list of beans
- *
- */
 @CommandLine.Command(
     name = "beans",
     description = "List available beans under a domain or all domains",
     footer =
         "Without -d option, current select domain is applied. If there's no domain specified, all beans are listed. Example:\n beans\n beans -d java.lang")
 public class BeansCommand extends Command {
-  /**
-   * Get list of bean names under current domain
-   *
-   * @param session Current JMX session
-   * @param domainName Full domain name
-   * @return List of bean names
-   * @throws MalformedObjectNameException Input domain name is malformed
-   * @throws IOException Communication error
-   */
   public static List<String> getBeans(Session session, String domainName)
       throws MalformedObjectNameException, IOException {
     ObjectName queryName = domainName == null ?  null : new ObjectName(domainName + ":*");
@@ -71,7 +58,6 @@ public class BeansCommand extends Command {
     }
   }
 
-  /** @param domain Domain under which beans are listed */
   @Option(
       names = {"-d", "--domain"},
       paramLabel = "domain",

--- a/src/main/java/sh/jmx/jmxsh/cmd/CloseCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/CloseCommand.java
@@ -6,10 +6,6 @@ import sh.jmx.jmxsh.Command;
 import picocli.CommandLine;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Command to close current connection
- *
- */
 @CommandLine.Command(name = "close", description = "Close current JMX connection")
 @Slf4j
 public class CloseCommand extends Command {

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainCommand.java
@@ -13,10 +13,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Get or set current selected domain
- *
- */
 @CommandLine.Command(
     name = "domain",
     description = "Display or set current selected domain. ",
@@ -25,14 +21,6 @@ import lombok.extern.slf4j.Slf4j;
             + " eg. domain java.lang")
 @Slf4j
 public class DomainCommand extends Command {
-  /**
-   * Get domain name from given domain expression
-   *
-   * @param domain Domain expression, which can be a name or NULL
-   * @param session Current JMX session
-   * @return String name of domain coming from given parameter or current session
-   * @throws IOException
-   */
   static String getDomainName(String domain, Session session) {
     Objects.requireNonNull(session, "Session can't be NULL");
     if (session.getConnection() == null) {
@@ -83,7 +71,6 @@ public class DomainCommand extends Command {
     }
   }
 
-  /** @param domain Domain to select */
   @Parameters(paramLabel = "domain", description = "Name of domain to set", arity = "0..1")
   public final void setDomain(String domain) {
     this.domain = domain;

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainsCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainsCommand.java
@@ -10,18 +10,8 @@ import sh.jmx.jmxsh.io.RuntimeIOException;
 
 import picocli.CommandLine;
 
-/**
- * List domains for JMX connection
- *
- */
 @CommandLine.Command(name = "domains", description = "List all available domain names")
 public class DomainsCommand extends Command {
-  /**
-   * Gets list of domains for current JMX connection.
-   *
-   * @param session The current session.
-   * @return List of available domain names.
-   */
   static List<String> getCandidateDomains(Session session) {
     String[] domains;
     try {

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -24,10 +24,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Get value of MBean attribute(s)
- *
- */
 @CommandLine.Command(
     name = "get",
     description = "Get value of MBean attribute(s)",
@@ -154,14 +150,12 @@ public class GetCommand extends Command {
     displayAttributes();
   }
 
-  /** @param attributes List of attribute names */
   @Parameters(paramLabel = "attr", description = "Name of attributes to select", arity = "1..*")
   public final void setAttributes(List<String> attributes) {
     Objects.requireNonNull(attributes, "Attributes can't be NULL");
     this.attributes = attributes;
   }
 
-  /** @param bean Bean under which attribute is get */
   @Option(
       names = {"-b", "--bean"},
       description = "MBean name where the attribute is. Optional if bean has been set")
@@ -169,25 +163,21 @@ public class GetCommand extends Command {
     this.bean = bean;
   }
 
-  /** @param domain Domain under which bean is selected */
   @Option(names = {"-d", "--domain"}, description = "Domain of bean, optional")
   public final void setDomain(String domain) {
     this.domain = domain;
   }
 
-  /** @param showDescription True to show detail description */
   @Option(names = {"-i", "--info"}, description = "Show detail information of each attribute")
   public final void setShowDescription(boolean showDescription) {
     this.showDescription = showDescription;
   }
 
-  /** @param noQuotationMarks True if value is not surrounded by quotation marsk */
   @Option(names = {"-q", "--quots"}, description = "Quotation marks around value")
   public final void setShowQuotationMarks(boolean noQuotationMarks) {
     this.showQuotationMarks = noQuotationMarks;
   }
 
-  /** @param simpleFormat True if value is printed out in a simple format without full expression */
   @Option(
       names = {"-s", "--simple"},
       description = "Print simple expression of value without full expression")
@@ -195,10 +185,6 @@ public class GetCommand extends Command {
     this.simpleFormat = simpleFormat;
   }
 
-  /**
-   * @param completeLine True if value is printed out in a complete &lt;/bean # value&gt; single
-   *     line expression
-   */
   @Option(
       names = {"-f", "--completeLine"},
       description = "Print expression with bean and value in single line with '#' delimiter.")

--- a/src/main/java/sh/jmx/jmxsh/cmd/InfoCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/InfoCommand.java
@@ -23,10 +23,6 @@ import sh.jmx.jmxsh.Session;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
-/**
- * Command that displays attributes and operations of an MBean
- *
- */
 @CommandLine.Command(
     name = "info",
     description = "Display detail information about an MBean",
@@ -198,29 +194,21 @@ public class InfoCommand extends Command {
     }
   }
 
-  /** @param bean Bean for which information is displayed */
   @Option(names = {"-b", "--bean"}, description = "Name of MBean")
   public final void setBean(String bean) {
     this.bean = bean;
   }
 
-  /**
-   * Given domain
-   *
-   * @param domain Domain name
-   */
   @Option(names = {"-d", "--domain"}, description = "Domain for bean")
   public final void setDomain(String domain) {
     this.domain = domain;
   }
 
-  /** @param showDescription True to show detail description */
   @Option(names = {"-e", "--detail"}, description = "Show description")
   public final void setShowDescription(boolean showDescription) {
     this.showDescription = showDescription;
   }
 
-  /** @param type Type of detail to display */
   @Option(
       names = {"-t", "--type"},
       description =

--- a/src/main/java/sh/jmx/jmxsh/cmd/JvmsCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/JvmsCommand.java
@@ -13,10 +13,6 @@ import picocli.CommandLine.Option;
 import lombok.extern.slf4j.Slf4j;
 import sh.jmx.jmxsh.attach.JavaProcess;
 
-/**
- * Command to list all running local JVM processes
- *
- */
 @CommandLine.Command(name = "jvms", description = "List all running local JVM processes")
 @Slf4j
 public class JvmsCommand extends Command {
@@ -39,7 +35,6 @@ public class JvmsCommand extends Command {
     }
   }
 
-  /** @param pidOnly Flag to notify command to only print out PID instead of more details */
   @Option(names = {"-p", "--pidonly"}, description = "Only print out PID")
   public final void setPidOnly(boolean pidOnly) {
     this.pidOnly = pidOnly;

--- a/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
@@ -17,10 +17,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Command to open JMX connection
- *
- */
 @CommandLine.Command(
     name = "open",
     description = "Open JMX session or display current connection",
@@ -86,7 +82,6 @@ public class OpenCommand extends Command {
     }
   }
 
-  /** @param password Password for user authentication */
   @Option(
       names = {"-p", "--password"},
       description = "Password for user/password authentication")
@@ -94,22 +89,16 @@ public class OpenCommand extends Command {
     this.password = password;
   }
 
-  /** @param url URL of MBean service to open */
   @Parameters(paramLabel = "url", description = "URL, <host>:<port>, jmxmp://<host>:<port>, or a PID to connect to", arity = "0..1")
   public final void setUrl(String url) {
     this.url = url;
   }
 
-  /** @param user User name for user authentication */
   @Option(names = {"-u", "--user"}, description = "User name for user/password authentication")
   public final void setUser(String user) {
     this.user = user;
   }
 
-  /**
-   * @param isSecureRmiRegistry Whether the server's RMI registry is protected with SSL/TLS
-   *     (com.sun.management.jmxremote.registry.ssl=true)
-   */
   @Option(
       names = {"-s", "--sslrmiregistry"},
       description = "Whether the server's RMI registry is protected with SSL/TLS")

--- a/src/main/java/sh/jmx/jmxsh/cmd/QuitCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/QuitCommand.java
@@ -6,10 +6,6 @@ import sh.jmx.jmxsh.Session;
 
 import picocli.CommandLine;
 
-/**
- * Command to terminate the console
- *
- */
 @CommandLine.Command(name = "quit", aliases = {"exit", "bye"}, description = "Terminate console and exit")
 public class QuitCommand extends Command {
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
@@ -24,10 +24,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Command to run an MBean operation
- *
- */
 @CommandLine.Command(
     name = "run",
     description = "Invoke an MBean operation",
@@ -86,7 +82,6 @@ public class RunCommand extends Command {
     MBeanServerConnection con = session.getConnection().getServerConnection();
     MBeanInfo beanInfo = con.getMBeanInfo(name);
 
-    // Looking for operation to invoke
     MBeanOperationInfo operationInfo = null;
     for (MBeanOperationInfo info : beanInfo.getOperations()) {
       if (operationName.equals(info.getName())
@@ -117,7 +112,6 @@ public class RunCommand extends Command {
         }
       }
     }
-    // If no matching operation is found, throw an exception
     if (operationInfo == null) {
       throw new IllegalArgumentException(
           "Operation "
@@ -128,7 +122,6 @@ public class RunCommand extends Command {
               + beanName);
     }
 
-    // Now set parameters to invoke with
     Object[] params = new Object[parameters.size() - 1];
     MBeanParameterInfo[] paramInfos = operationInfo.getSignature();
     if (params.length != paramInfos.length) {
@@ -150,7 +143,6 @@ public class RunCommand extends Command {
         "calling operation %s of mbean %s with params %s".formatted(
             operationName, beanName, Arrays.toString(params)));
 
-    // Invoke operation, record execution time if measure flag is on
     Object result;
     if (measure) {
       long start = System.nanoTime();
@@ -165,23 +157,19 @@ public class RunCommand extends Command {
     }
     session.getOutput().printMessage("operation returns: ");
     new ValueOutputFormat(2, false, showQuotationMarks).printValue(session.getOutput(), result);
-    // Finish with an empty line
     session.getOutput().println("");
   }
 
-  /** @param bean Bean under which the operation is */
   @Option(names = {"-b", "--bean"}, description = "MBean to invoke")
   public final void setBean(String bean) {
     this.bean = bean;
   }
 
-  /** @param domain Domain under which is bean is */
   @Option(names = {"-d", "--domain"}, description = "Domain of MBean to invoke")
   public final void setDomain(String domain) {
     this.domain = domain;
   }
 
-  /** @param measure True if you want to display latency */
   @Option(
       names = {"-m", "--measure"},
       description = "Measure the time spent on the invocation of operation")
@@ -196,7 +184,6 @@ public class RunCommand extends Command {
     this.types = types;
   }
 
-  /** @param parameters List of parameters. The first parameter is operation name */
   @Parameters(
       description = "The first parameter is operation name, which is followed by list of arguments",
       arity = "1..*")
@@ -205,7 +192,6 @@ public class RunCommand extends Command {
     this.parameters = parameters;
   }
 
-  /** @param showQuotationMarks True if output is surrounded by quotation marks */
   @Option(names = {"-q", "--quots"}, description = "Flag for quotation marks")
   public final void setShowQuotationMarks(boolean showQuotationMarks) {
     this.showQuotationMarks = showQuotationMarks;

--- a/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
@@ -23,10 +23,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Command to set an attribute
- *
- */
 @CommandLine.Command(name = "set", description = "Set value of an MBean attribute")
 @Slf4j
 public class SetCommand extends Command {
@@ -95,14 +91,12 @@ public class SetCommand extends Command {
     session.getOutput().printMessage("Value of attribute " + attributeName + " is set to " + inputValue);
   }
 
-  /** @param arguments Argument list. The first argument is attribute name */
   @Parameters(description = "name, value, value2...", arity = "2..*")
   public final void setArguments(List<String> arguments) {
     Objects.requireNonNull(arguments, "Arguments can't be NULL");
     this.arguments = arguments;
   }
 
-  /** @param bean Bean where the attribute is */
   @Option(
       names = {"-b", "--bean"},
       description = "MBean name where the attribute is. Optional if bean has been set")
@@ -110,7 +104,6 @@ public class SetCommand extends Command {
     this.bean = bean;
   }
 
-  /** @param domain Domain where the bean is */
   @Option(names = {"-d", "--domain"}, description = "Domain under which the bean is")
   public final void setDomain(String domain) {
     this.domain = domain;

--- a/src/main/java/sh/jmx/jmxsh/cmd/SubscribeCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SubscribeCommand.java
@@ -81,13 +81,11 @@ public class SubscribeCommand extends Command {
     }
   }
 
-  /** @param bean Bean under which the operation is */
   @Option(names = {"-b", "--bean"}, description = "MBean to invoke")
   public final void setBean(String bean) {
     this.bean = bean;
   }
 
-  /** @param domain Domain under which is bean is */
   @Option(names = {"-d", "--domain"}, description = "Domain of MBean to invoke")
   public final void setDomain(String domain) {
     this.domain = domain;

--- a/src/main/java/sh/jmx/jmxsh/cmd/UnsubscribeCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/UnsubscribeCommand.java
@@ -15,9 +15,7 @@ import picocli.CommandLine.Option;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Command to subscribe to an MBean notification
- *
- * <p>Remove the subscription of an already subscribed notification listener. Notifications will no
+ * Removes the subscription of an already subscribed notification listener. Notifications will no
  * longer be sent to the session output.
  */
 @CommandLine.Command(
@@ -50,13 +48,11 @@ public class UnsubscribeCommand extends Command {
     }
   }
 
-  /** @param bean Bean under which the operation is */
   @Option(names = {"-b", "--bean"}, description = "MBean to invoke")
   public final void setBean(String bean) {
     this.bean = bean;
   }
 
-  /** @param domain Domain under which is bean is */
   @Option(names = {"-d", "--domain"}, description = "Domain of MBean to invoke")
   public final void setDomain(String domain) {
     this.domain = domain;

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -35,38 +35,9 @@ import lombok.extern.slf4j.Slf4j;
     footer = "DO NOT call this command in a script and expect decent output")
 @Slf4j
 public class WatchCommand extends Command {
-  private static final class ConsoleOutput extends Output {
-    private final LineReaderImpl console;
-
-    private ConsoleOutput(Session session) {
-      if (!(session.getInput() instanceof JlineCommandInput)) {
-        throw new IllegalStateException("Under current context, watch command can't execute.");
-      }
-      this.console = ((JlineCommandInput) session.getInput()).getConsole();
-    }
-
-    void printLine(String line) throws IOException {
-      console.redrawLine();
-      console.getTerminal().writer().print(line);
-      console.flush();
-    }
-  }
-
-  private abstract static class Output {
-    abstract void printLine(String line) throws IOException;
-  }
-
-  private static final class ReportOutput extends Output {
-    private final CommandOutput out;
-
-    private ReportOutput(Session session) {
-      this.out = session.getOutput();
-    }
-
-    @Override
-    void printLine(String line) {
-      out.println(line);
-    }
+  @FunctionalInterface
+  private interface LineOutput {
+    void printLine(String line) throws IOException;
   }
 
   private static final String BUILDING_ATTRIBUTE_NOW = "%now";
@@ -117,11 +88,20 @@ public class WatchCommand extends Command {
 
     final ObjectName name = new ObjectName(beanName);
     final MBeanServerConnection con = session.getConnection().getServerConnection();
-    final Output output;
+    final LineOutput output;
     if (report) {
-      output = new ReportOutput(session);
+      CommandOutput out = session.getOutput();
+      output = line -> out.println(line);
     } else {
-      output = new ConsoleOutput(session);
+      if (!(session.getInput() instanceof JlineCommandInput jlineInput)) {
+        throw new IllegalStateException("Under current context, watch command can't execute.");
+      }
+      LineReaderImpl console = jlineInput.getConsole();
+      output = line -> {
+        console.redrawLine();
+        console.getTerminal().writer().print(line);
+        console.flush();
+      };
       getSession().getOutput().printMessage("press any key to stop. DO NOT press Ctrl+C !!!");
     }
 
@@ -167,7 +147,7 @@ public class WatchCommand extends Command {
     }
   }
 
-  private void printValues(ObjectName beanName, MBeanServerConnection connection, Output output)
+  private void printValues(ObjectName beanName, MBeanServerConnection connection, LineOutput output)
       throws IOException {
     String result;
     if (outputFormat == null) {

--- a/src/main/java/sh/jmx/jmxsh/io/CommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/CommandInput.java
@@ -4,12 +4,12 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * An abstract class that provides command line input line by line
+ * Interface that provides command line input line by line
  *
  */
-public abstract class CommandInput implements Closeable {
+public interface CommandInput extends Closeable {
   @Override
-  public void close() throws IOException {}
+  default void close() throws IOException {}
 
   /**
    * Reads a single line from input.
@@ -17,7 +17,7 @@ public abstract class CommandInput implements Closeable {
    * @return The line it reads.
    * @throws IOException allows any communication error.
    */
-  public abstract String readLine() throws IOException;
+  String readLine() throws IOException;
 
   /**
    * Reads input without echoing back keyboard input.
@@ -26,5 +26,5 @@ public abstract class CommandInput implements Closeable {
    * @return The string it reads.
    * @throws IOException allows any communication error.
    */
-  public abstract String readMaskedString(String prompt) throws IOException;
+  String readMaskedString(String prompt) throws IOException;
 }

--- a/src/main/java/sh/jmx/jmxsh/io/CommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/CommandOutput.java
@@ -1,29 +1,29 @@
 package sh.jmx.jmxsh.io;
 
 /**
- * General abstract class to output message and values
+ * Interface to output messages and values
  *
  */
-public abstract class CommandOutput {
-  /** Close the output; */
-  public void close() {}
+public interface CommandOutput {
+  /** Close the output. */
+  default void close() {}
 
   /**
    * Print out value to output without line break
    *
    * @param output Value to print out
    */
-  public abstract void print(String output);
+  void print(String output);
 
   /** @param e Error to print out */
-  public abstract void printError(Throwable e);
+  void printError(Throwable e);
 
   /**
    * Print out value to output as standalone line
    *
    * @param output Value to print out
    */
-  public void println(String output) {
+  default void println(String output) {
     print(output);
     print(System.lineSeparator());
   }
@@ -33,5 +33,5 @@ public abstract class CommandOutput {
    *
    * @param message Message to print out.
    */
-  public abstract void printMessage(String message);
+  void printMessage(String message);
 }

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandInput.java
@@ -11,7 +11,7 @@ import java.util.Objects;
  * Implementation of CommandInput with given File
  *
  */
-public class FileCommandInput extends CommandInput {
+public class FileCommandInput implements CommandInput {
   private final LineNumberReader in;
 
   /**

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandInput.java
@@ -7,19 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
-/**
- * Implementation of CommandInput with given File
- *
- */
 public class FileCommandInput implements CommandInput {
   private final LineNumberReader in;
 
-  /**
-   * Read input from a given file
-   *
-   * @param inputFile Given input file
-   * @throws IOException Thrown when file doesn't exist or can't be read
-   */
   public FileCommandInput(Path inputFile) throws IOException {
     Objects.requireNonNull(inputFile, "Input can't be NULL");
     this.in = new LineNumberReader(Files.newBufferedReader(inputFile, StandardCharsets.UTF_8));

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
@@ -9,20 +9,11 @@ import java.nio.file.StandardOpenOption;
 
 import java.util.Objects;
 
-/**
- * Output with a file
- *
- */
 public class FileCommandOutput implements CommandOutput {
   private final PrintWriter fileWriter;
 
   private final WriterCommandOutput output;
 
-  /**
-   * @param file where the result is written to.
-   * @param appendToOutput whether to write to output.
-   * @throws IOException allows IO error.
-   */
   public FileCommandOutput(Path file, boolean appendToOutput) throws IOException {
     Objects.requireNonNull(file, "File can't be NULL");
     Path af = file.toAbsolutePath();

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  * Output with a file
  *
  */
-public class FileCommandOutput extends CommandOutput {
+public class FileCommandOutput implements CommandOutput {
   private final PrintWriter fileWriter;
 
   private final WriterCommandOutput output;

--- a/src/main/java/sh/jmx/jmxsh/io/InputStreamCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/InputStreamCommandInput.java
@@ -7,14 +7,9 @@ import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-/**
- * Implementation of {@link CommandInput} with an input stream
- *
- */
 public class InputStreamCommandInput implements CommandInput {
   private final LineNumberReader reader;
 
-  /** @param in Given input stream */
   public InputStreamCommandInput(InputStream in) {
     Objects.requireNonNull(in, "Input stream can't be NULL");
     reader = new LineNumberReader(new InputStreamReader(in, StandardCharsets.UTF_8));

--- a/src/main/java/sh/jmx/jmxsh/io/InputStreamCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/InputStreamCommandInput.java
@@ -11,7 +11,7 @@ import java.util.Objects;
  * Implementation of {@link CommandInput} with an input stream
  *
  */
-public class InputStreamCommandInput extends CommandInput {
+public class InputStreamCommandInput implements CommandInput {
   private final LineNumberReader reader;
 
   /** @param in Given input stream */

--- a/src/main/java/sh/jmx/jmxsh/io/JlineCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/JlineCommandInput.java
@@ -8,7 +8,7 @@ import org.jline.reader.impl.LineReaderImpl;
  * Implementation of input that reads command from jloin console input
  *
  */
-public class JlineCommandInput extends CommandInput {
+public class JlineCommandInput implements CommandInput {
   private final LineReaderImpl console;
 
   private final String prompt;

--- a/src/main/java/sh/jmx/jmxsh/io/JlineCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/JlineCommandInput.java
@@ -4,26 +4,17 @@ import java.io.IOException;
 import java.util.Objects;
 import org.jline.reader.impl.LineReaderImpl;
 
-/**
- * Implementation of input that reads command from jloin console input
- *
- */
 public class JlineCommandInput implements CommandInput {
   private final LineReaderImpl console;
 
   private final String prompt;
 
-  /**
-   * @param console Jline console reader
-   * @param prompt Prompt string
-   */
   public JlineCommandInput(LineReaderImpl console, String prompt) {
     Objects.requireNonNull(console, "Jline console reader can't be NULL");
     this.console = console;
     this.prompt = prompt == null ? "" : prompt.trim();
   }
 
-  /** @return Jline console */
   public final LineReaderImpl getConsole() {
     return console;
   }

--- a/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
@@ -3,33 +3,19 @@ package sh.jmx.jmxsh.io;
 import java.io.PrintStream;
 import java.util.Objects;
 
-/**
- * Implementation of CommandOutput where output is written in given PrintStream objects
- *
- */
 public class PrintStreamCommandOutput implements CommandOutput {
   private final PrintStream messageOutput;
 
   private final PrintStream resultOutput;
 
-  /** Default constructor that uses system standard output and err output */
   public PrintStreamCommandOutput() {
     this(System.out);
   }
 
-  /**
-   * Constructor with given result output and system error as message output
-   *
-   * @param output Output for result
-   */
   public PrintStreamCommandOutput(PrintStream output) {
     this(output, System.err);
   }
 
-  /**
-   * @param resultOutput PrintStream where result is written to
-   * @param messageOutput PrintStream where message is written to
-   */
   public PrintStreamCommandOutput(PrintStream resultOutput, PrintStream messageOutput) {
     Objects.requireNonNull(resultOutput, "Result output can't be NULL");
     Objects.requireNonNull(messageOutput, "Message output can't be NULL");

--- a/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Implementation of CommandOutput where output is written in given PrintStream objects
  *
  */
-public class PrintStreamCommandOutput extends CommandOutput {
+public class PrintStreamCommandOutput implements CommandOutput {
   private final PrintStream messageOutput;
 
   private final PrintStream resultOutput;

--- a/src/main/java/sh/jmx/jmxsh/io/RuntimeIOException.java
+++ b/src/main/java/sh/jmx/jmxsh/io/RuntimeIOException.java
@@ -3,18 +3,10 @@ package sh.jmx.jmxsh.io;
 import java.io.IOException;
 import java.io.Serial;
 
-/**
- * Unchecked version of IOException
- *
- */
 public class RuntimeIOException extends RuntimeException {
   @Serial
   private static final long serialVersionUID = -2304094504586109315L;
 
-  /**
-   * @param message Error message
-   * @param e Original IOException
-   */
   public RuntimeIOException(String message, IOException e) {
     super(message, e);
   }

--- a/src/main/java/sh/jmx/jmxsh/io/UnimplementedCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/UnimplementedCommandInput.java
@@ -6,7 +6,7 @@ import java.io.IOException;
  * Unimplemented version of command input
  *
  */
-public class UnimplementedCommandInput extends CommandInput {
+public class UnimplementedCommandInput implements CommandInput {
   @Override
   public String readLine() throws IOException {
     throw new UnsupportedOperationException();

--- a/src/main/java/sh/jmx/jmxsh/io/UnimplementedCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/UnimplementedCommandInput.java
@@ -2,10 +2,6 @@ package sh.jmx.jmxsh.io;
 
 import java.io.IOException;
 
-/**
- * Unimplemented version of command input
- *
- */
 public class UnimplementedCommandInput implements CommandInput {
   @Override
   public String readLine() throws IOException {

--- a/src/main/java/sh/jmx/jmxsh/io/ValueOutputFormat.java
+++ b/src/main/java/sh/jmx/jmxsh/io/ValueOutputFormat.java
@@ -8,10 +8,6 @@ import javax.management.openmbean.CompositeData;
 
 
 
-/**
- * A utility to print out object values in particular format.
- *
- */
 public class ValueOutputFormat {
   private final int indentSize;
 
@@ -19,18 +15,10 @@ public class ValueOutputFormat {
 
   private final boolean showQuotationMarks;
 
-  /**
-   * Default constructor with indentiation = 2, showDescription and showQuotationMarks are both true
-   */
   public ValueOutputFormat() {
     this(2, true, true);
   }
 
-  /**
-   * @param indentSize Size of indentation
-   * @param showDescription True if value description is printed
-   * @param showQuotationMarks True if quotation mark is printed
-   */
   public ValueOutputFormat(int indentSize, boolean showDescription, boolean showQuotationMarks) {
     if (indentSize < 0) {
       throw new IllegalArgumentException("Invalid indent size value " + indentSize);
@@ -40,27 +28,10 @@ public class ValueOutputFormat {
     this.showQuotationMarks = showQuotationMarks;
   }
 
-  /**
-   * Print out equal expression of an variable with description
-   *
-   * @param output Output to print to
-   * @param name Name of variable
-   * @param value Value of variable
-   * @param description Description of variable
-   */
   public void printExpression(CommandOutput output, Object name, Object value, String description) {
     printExpression(output, name, value, description, 0);
   }
 
-  /**
-   * Print out equal expression of an variable with description
-   *
-   * @param output Output to print to
-   * @param name Name of variable
-   * @param value Value of variable
-   * @param description Description of variable
-   * @param indent Starting indent position
-   */
   private void printExpression(
       CommandOutput output, Object name, Object value, String description, int indent) {
     output.print(" ".repeat(indent));
@@ -74,21 +45,10 @@ public class ValueOutputFormat {
     output.println("");
   }
 
-  /**
-   * @param output Output writer where value is printed to
-   * @param value Value to print
-   */
   public void printValue(CommandOutput output, Object value) {
     printValue(output, value, 0);
   }
 
-  /**
-   * Print out expression of given value considering various possible types of value
-   *
-   * @param output Output writer where value is printed
-   * @param value Object value which can be anything
-   * @param indent Starting indentation length
-   */
   private void printValue(CommandOutput output, Object value, int indent) {
     if (value == null) {
       output.print("null");

--- a/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
  * are immediately reflected.
  */
 @Slf4j
-public class VerboseCommandOutput extends CommandOutput {
+public class VerboseCommandOutput implements CommandOutput {
 
   private final CommandOutput output;
   private final Supplier<OutputMode> modeSupplier;

--- a/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * A command output that writes result and message to given writers
  *
  */
-public class WriterCommandOutput extends CommandOutput {
+public class WriterCommandOutput implements CommandOutput {
   private final Writer messageOutput;
 
   private final Writer resultOutput;

--- a/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
@@ -4,24 +4,15 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Objects;
 
-/**
- * A command output that writes result and message to given writers
- *
- */
 public class WriterCommandOutput implements CommandOutput {
   private final Writer messageOutput;
 
   private final Writer resultOutput;
 
-  /** @param output Writer for both result and message */
   public WriterCommandOutput(Writer output) {
     this(output, output);
   }
 
-  /**
-   * @param resultOutput IO Writer for result output
-   * @param messageOutput IO Writer for message output
-   */
   public WriterCommandOutput(Writer resultOutput, Writer messageOutput) {
     Objects.requireNonNull(resultOutput, "Result output can't be NULL");
     this.resultOutput = resultOutput;

--- a/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
@@ -7,17 +7,10 @@ package sh.jmx.jmxsh.utils;
  *
  */
 public final class ValueFormat {
-  /** Keyword that identifies NULL pointer <code>null</code> */
   public static final String NULL = "null";
 
   private ValueFormat() {}
 
-  /**
-   * Parse given syntax of string
-   *
-   * @param value String value
-   * @return Escaped string value
-   */
   public static String parseValue(String value) {
     if (value == null || value.isEmpty()) {
       return null;


### PR DESCRIPTION
## Summary

Two structural refactors from TODO.md:

### 1 — `CommandInput` and `CommandOutput` → interfaces

Both abstract classes had only abstract methods plus one or two trivial concrete defaults — a perfect fit for Java interfaces with `default` methods.

- `CommandInput`: `close()` becomes `default void close() throws IOException {}`
- `CommandOutput`: `close()` and `println()` become `default` methods
- 8 implementation classes updated: `extends` → `implements` (no logic changes)

### 2 — `WatchCommand` inner class hierarchy → `@FunctionalInterface`

Removed the `Output` / `ConsoleOutput` / `ReportOutput` three-class hierarchy (~30 lines) that existed solely to abstract a single `printLine(String)` call.

- Added one `@FunctionalInterface private interface LineOutput`
- Replaced `new ConsoleOutput(session)` / `new ReportOutput(session)` with two lambdas
- Used `instanceof` pattern variable to eliminate a manual cast

## Testing

`mvn verify` passes (all unit + integration + E2E tests green).