### PR TITLE
ci: add JaCoCo coverage and SonarCloud analysis

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -9,12 +9,16 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  statuses: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -22,4 +26,7 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - run: mvn --no-transfer-progress verify
+      - run: mvn --no-transfer-progress verify sonar:sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ and dependency graph. Items are organized by category. Each item is labeled with
 ## Build / POM
 
 - 🟠 **Add `maven-enforcer-plugin` rules** — The plugin is in `pluginManagement` but has no active rules. Add: `requireMavenVersion` (≥ 3.8), `requireJavaVersion` (≥ 25), `banDuplicatePomDependencyVersions`, `dependencyConvergence`.
-- 🟡 **Add static analysis plugin** — No static analysis is currently configured. Consider SpotBugs (`spotbugs-maven-plugin`), Checkstyle (`maven-checkstyle-plugin`), or ErrorProne for compile-time bug detection.
 - 🟡 **Add `.editorconfig`** — Not present. Ensures consistent indentation, charset, and line endings across IDEs and editors.
 - 🟡 **Add `.gitattributes`** — Not present. Normalizes line endings (`* text=auto`, `*.java text eol=lf`, `*.sh text eol=lf`) and marks binary files.
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,10 +20,6 @@ and dependency graph. Items are organized by category. Each item is labeled with
 - 🟡 **Add `.editorconfig`** — Not present. Ensures consistent indentation, charset, and line endings across IDEs and editors.
 - 🟡 **Add `.gitattributes`** — Not present. Normalizes line endings (`* text=auto`, `*.java text eol=lf`, `*.sh text eol=lf`) and marks binary files.
 
-## Testing
-
-- 🟡 **Add test coverage reporting (JaCoCo)** — No coverage tool is configured. Add `jacoco-maven-plugin` to generate reports and optionally enforce minimum coverage thresholds.
-
 ## Legacy
 
 ### Legacy Architecture

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,14 @@
     <assertj.version>3.27.7</assertj.version>
     <junit.version>6.0.3</junit.version>
 
+    <!-- SonarCloud -->
+    <sonar.organization>nyg</sonar.organization>
+    <sonar.projectKey>nyg_jmxsh</sonar.projectKey>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+
     <!-- Plugins -->
+    <jacoco.version>0.8.14</jacoco.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
@@ -219,6 +226,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
+          <argLine>@{argLine}</argLine>
           <excludes>
             <exclude>sh.jmx.jmxsh.jdk*</exclude>
           </excludes>
@@ -229,6 +237,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
         <configuration>
+          <argLine>@{argLine}</argLine>
           <includes>
             <include>**/*IT.java</include>
           </includes>
@@ -239,6 +248,42 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco.exec</destFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>prepare-agent-integration</id>
+            <goals>
+              <goal>prepare-agent-integration</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco.exec</destFile>
+              <append>true</append>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary

Configures code coverage reporting for SonarCloud.

### Changes

**`pom.xml`**
- Add `jacoco-maven-plugin` 0.8.14 (first version with Java 25 support) with three executions:
  - `prepare-agent` — instruments unit tests (surefire)
  - `prepare-agent-integration` — instruments integration tests (failsafe), appends to the same `target/jacoco.exec`
  - `report` at `verify` phase — reads combined exec and writes `target/site/jacoco/jacoco.xml`
- Add `@{argLine}` to surefire and failsafe configs so the JaCoCo Java agent is applied at test runtime
- Add SonarCloud properties: `sonar.organization`, `sonar.projectKey`, `sonar.host.url`, `sonar.coverage.jacoco.xmlReportPaths`

**`.github/workflows/java-ci.yaml`**
- Add `fetch-depth: 0` to checkout (required for SonarCloud blame data and branch detection)
- Add `pull-requests: write` and `statuses: write` permissions (for PR decoration)
- Run `mvn verify sonar:sonar` with `SONAR_TOKEN` and `GITHUB_TOKEN`

### Post-merge action required

In SonarCloud → Project → Administration → Analysis Method: **disable Automatic Analysis** to avoid duplicate analyses now that CI-based analysis is active.