### PR TITLE
fix: remediate SonarQube issues

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/Command.java
+++ b/src/main/java/sh/jmx/jmxsh/Command.java
@@ -23,11 +23,11 @@ public abstract class Command implements Completable {
   private Session session;
 
   protected List<String> doSuggestArgument() throws IOException, JMException {
-    return null;
+    return List.of();
   }
 
   protected List<String> doSuggestOption(String optionName) throws IOException, JMException {
-    return null;
+    return List.of();
   }
 
   public abstract void execute() throws IOException, JMException;
@@ -52,7 +52,7 @@ public abstract class Command implements Completable {
 
   public final List<String> suggestArgument(String partialArg) {
     if (partialArg != null) {
-      return null;
+      return List.of();
     }
     try {
       return doSuggestArgument();
@@ -60,13 +60,13 @@ public abstract class Command implements Completable {
       if (log.isDebugEnabled()) {
         log.debug("Couldn't suggest argument", e);
       }
-      return null;
+      return List.of();
     }
   }
 
   public final List<String> suggestOption(String name, String partialValue) {
     if (partialValue != null) {
-      return null;
+      return List.of();
     }
     try {
       return doSuggestOption(name);
@@ -74,7 +74,7 @@ public abstract class Command implements Completable {
       if (log.isDebugEnabled()) {
         log.debug("Couldn't suggest option", e);
       }
-      return null;
+      return List.of();
     }
   }
 }

--- a/src/main/java/sh/jmx/jmxsh/Command.java
+++ b/src/main/java/sh/jmx/jmxsh/Command.java
@@ -22,10 +22,12 @@ public abstract class Command implements Completable {
 
   private Session session;
 
+  @SuppressWarnings("java:S1130") // throws are required API contract for subclass overrides
   protected List<String> doSuggestArgument() throws IOException, JMException {
     return List.of();
   }
 
+  @SuppressWarnings("java:S1130") // throws are required API contract for subclass overrides
   protected List<String> doSuggestOption(String optionName) throws IOException, JMException {
     return List.of();
   }

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -93,7 +93,7 @@ public class CliMain {
     } else {
       output = new FileCommandOutput(Path.of(options.getOutput()), options.isAppendToOutput());
     }
-    try {
+    try (output) {
       CommandInput input;
       if (CliMainOptions.STDIN.equals(options.getInput())) {
         if (options.isNonInteractive()) {
@@ -180,8 +180,6 @@ public class CliMain {
       log.error("Fatal startup error", e);
       output.printError(e);
       return 1;
-    } finally {
-      output.close();
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/boot/LoggingConfigurator.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/LoggingConfigurator.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import sh.jmx.jmxsh.utils.AppConfig;
 import sh.jmx.jmxsh.utils.XdgDirectories;
 import org.slf4j.LoggerFactory;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -40,7 +41,7 @@ public final class LoggingConfigurator {
       return;
     }
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    Logger root = context.getLogger(Logger.ROOT_LOGGER_NAME);
+    Logger root = context.getLogger(ROOT_LOGGER_NAME);
 
     // Detach any pre-existing FILE appender that failed to start on a previous call.
     Appender<ILoggingEvent> existing = root.getAppender("FILE");

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -44,7 +44,7 @@ public class CommandCenter {
 
   final Session session;
 
-  public CommandCenter(CommandOutput output, CommandInput input) throws IOException {
+  public CommandCenter(CommandOutput output, CommandInput input) {
     this(output, input, new PredefinedCommandFactory());
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
@@ -43,7 +43,8 @@ public class BeanCommand extends Command {
         ObjectName name = new ObjectName(bean);
         con.getMBeanInfo(name);
         return bean;
-      } catch (MalformedObjectNameException | InstanceNotFoundException e) {
+      } catch (MalformedObjectNameException | InstanceNotFoundException _) {
+        // Invalid or unknown bean name — fall through to domain-qualified lookup
       }
     }
 
@@ -56,7 +57,8 @@ public class BeanCommand extends Command {
       ObjectName name = new ObjectName(domainName + ":" + bean);
       con.getMBeanInfo(name);
       return domainName + ":" + bean;
-    } catch (MalformedObjectNameException | InstanceNotFoundException e) {
+    } catch (MalformedObjectNameException | InstanceNotFoundException _) {
+      // Invalid or unknown bean name — fall through to throw IllegalArgumentException
     }
     throw new IllegalArgumentException("Bean name " + bean + " isn't valid");
   }
@@ -91,7 +93,7 @@ public class BeanCommand extends Command {
     if ("d".equals(optionName)) {
       return DomainsCommand.getCandidateDomains(getSession());
     }
-    return null;
+    return List.of();
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeansCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeansCommand.java
@@ -37,7 +37,7 @@ public class BeansCommand extends Command {
     if ("d".equals(optionName)) {
       return DomainsCommand.getCandidateDomains(getSession());
     }
-    return null;
+    return List.of();
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainBeanAwareCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainBeanAwareCommand.java
@@ -1,0 +1,21 @@
+package sh.jmx.jmxsh.cmd;
+
+import java.util.List;
+
+import javax.management.JMException;
+
+import sh.jmx.jmxsh.Command;
+
+/** Abstract command that provides domain/bean tab-completion for {@code -d} and {@code -b} options. */
+abstract class DomainBeanAwareCommand extends Command {
+
+  @Override
+  protected List<String> doSuggestOption(String optionName) throws JMException {
+    if ("d".equals(optionName)) {
+      return DomainsCommand.getCandidateDomains(getSession());
+    } else if ("b".equals(optionName)) {
+      return BeanCommand.getCandidateBeanNames(getSession());
+    }
+    return List.of();
+  }
+}

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -15,7 +15,6 @@ import javax.management.ObjectName;
 import javax.management.RuntimeMBeanException;
 import javax.management.openmbean.CompositeDataSupport;
 
-import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.Session;
 import sh.jmx.jmxsh.io.ValueOutputFormat;
 
@@ -29,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
     description = "Get value of MBean attribute(s)",
     footer = "* stands for all attributes. eg. get Attribute1 Attribute2 or get *")
 @Slf4j
-public class GetCommand extends Command {
+public class GetCommand extends DomainBeanAwareCommand {
   private List<String> attributes = new ArrayList<>();
 
   private String bean;
@@ -128,17 +127,6 @@ public class GetCommand extends Command {
       return Arrays.stream(ais).map(MBeanAttributeInfo::getName).toList();
     }
     return List.of();
-  }
-
-  @Override
-  protected List<String> doSuggestOption(String optionName) throws JMException {
-    if ("d".equals(optionName)) {
-      return DomainsCommand.getCandidateDomains(getSession());
-    } else if ("b".equals(optionName)) {
-      return BeanCommand.getCandidateBeanNames(getSession());
-    } else {
-      return List.of();
-    }
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -127,7 +127,7 @@ public class GetCommand extends Command {
           con.getMBeanInfo(new ObjectName(getSession().getBean())).getAttributes();
       return Arrays.stream(ais).map(MBeanAttributeInfo::getName).toList();
     }
-    return null;
+    return List.of();
   }
 
   @Override
@@ -137,7 +137,7 @@ public class GetCommand extends Command {
     } else if ("b".equals(optionName)) {
       return BeanCommand.getCandidateBeanNames(getSession());
     } else {
-      return null;
+      return List.of();
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
@@ -54,7 +54,7 @@ public class RunCommand extends Command {
       MBeanOperationInfo[] operationInfos = info.getOperations();
       return Arrays.stream(operationInfos).map(MBeanOperationInfo::getName).toList();
     }
-    return null;
+    return List.of();
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
@@ -13,7 +13,6 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.Session;
 import sh.jmx.jmxsh.SyntaxUtils;
 import sh.jmx.jmxsh.utils.ValueFormat;
@@ -25,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @CommandLine.Command(name = "set", description = "Set value of an MBean attribute")
 @Slf4j
-public class SetCommand extends Command {
+public class SetCommand extends DomainBeanAwareCommand {
   private List<String> arguments = Collections.emptyList();
 
   private String bean;
@@ -42,17 +41,6 @@ public class SetCommand extends Command {
       return Arrays.stream(attrs).map(MBeanAttributeInfo::getName).toList();
     }
     return List.of();
-  }
-
-  @Override
-  protected List<String> doSuggestOption(String optionName) throws JMException {
-    if ("d".equals(optionName)) {
-      return DomainsCommand.getCandidateDomains(getSession());
-    } else if ("b".equals(optionName)) {
-      return BeanCommand.getCandidateBeanNames(getSession());
-    } else {
-      return List.of();
-    }
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
@@ -41,7 +41,7 @@ public class SetCommand extends Command {
       MBeanAttributeInfo[] attrs = info.getAttributes();
       return Arrays.stream(attrs).map(MBeanAttributeInfo::getName).toList();
     }
-    return null;
+    return List.of();
   }
 
   @Override
@@ -51,7 +51,7 @@ public class SetCommand extends Command {
     } else if ("b".equals(optionName)) {
       return BeanCommand.getCandidateBeanNames(getSession());
     } else {
-      return null;
+      return List.of();
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -65,7 +65,7 @@ public class WatchCommand extends Command {
               Stream.of(BUILDING_ATTRIBUTE_NOW))
           .toList();
     }
-    return null;
+    return List.of();
   }
 
   @Override
@@ -91,7 +91,7 @@ public class WatchCommand extends Command {
     final LineOutput output;
     if (report) {
       CommandOutput out = session.getOutput();
-      output = line -> out.println(line);
+      output = out::println;
     } else {
       if (!(session.getInput() instanceof JlineCommandInput jlineInput)) {
         throw new IllegalStateException("Under current context, watch command can't execute.");

--- a/src/main/java/sh/jmx/jmxsh/io/CommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/CommandOutput.java
@@ -4,7 +4,7 @@ package sh.jmx.jmxsh.io;
  * Interface to output messages and values
  *
  */
-public interface CommandOutput {
+public interface CommandOutput extends AutoCloseable {
   /** Close the output. */
   default void close() {}
 

--- a/src/main/java/sh/jmx/jmxsh/utils/AppConfig.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/AppConfig.java
@@ -39,7 +39,7 @@ public final class AppConfig {
     if (Files.isRegularFile(configFile)) {
       try (InputStream in = Files.newInputStream(configFile)) {
         props.load(in);
-      } catch (IOException e) {
+      } catch (IOException _) {
         // Silently fall back to defaults if the file cannot be read.
       }
     }
@@ -83,7 +83,7 @@ public final class AppConfig {
     try {
       Files.createDirectories(configFile.getParent());
       Files.writeString(configFile, DEFAULT_CONFIG_CONTENT, StandardCharsets.UTF_8);
-    } catch (IOException e) {
+    } catch (IOException _) {
       // Non-fatal: if we cannot write the config, continue without it.
     }
   }

--- a/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
@@ -49,7 +49,7 @@ public final class ValueFormat {
             try {
               sb.append((char) Integer.parseInt(input.substring(i + 2, i + 6), 16));
               i += 5;
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException _) {
               sb.append("\\\\u");
               i++;
             }

--- a/src/test/java/sh/jmx/jmxsh/CommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/CommandTest.java
@@ -18,7 +18,9 @@ class CommandTest {
   /** Minimal Command subclass that throws from its doSuggest* methods to exercise catch branches. */
   private static class ThrowingCommand extends Command {
     @Override
-    public void execute() {}
+    public void execute() {
+      // no-op for testing
+    }
 
     @Override
     protected List<String> doSuggestArgument() throws IOException {

--- a/src/test/java/sh/jmx/jmxsh/CommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/CommandTest.java
@@ -1,0 +1,78 @@
+package sh.jmx.jmxsh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.management.JMException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommandTest {
+
+  /** Minimal Command subclass that throws from its doSuggest* methods to exercise catch branches. */
+  private static class ThrowingCommand extends Command {
+    @Override
+    public void execute() {}
+
+    @Override
+    protected List<String> doSuggestArgument() throws IOException {
+      throw new IOException("simulated failure");
+    }
+
+    @Override
+    protected List<String> doSuggestOption(String optionName) throws JMException {
+      throw new JMException("simulated failure");
+    }
+  }
+
+  @Mock
+  private Session session;
+
+  @Test
+  void suggestArgumentReturnsEmptyWhenPartialArgIsNonNull() {
+    SelfRecordingCommand cmd = new SelfRecordingCommand(new java.util.ArrayList<>());
+    cmd.setSession(session);
+    assertThat(cmd.suggestArgument("partial")).isEmpty();
+  }
+
+  @Test
+  void suggestArgumentCallsDoSuggestArgument() {
+    SelfRecordingCommand cmd = new SelfRecordingCommand(new java.util.ArrayList<>());
+    cmd.setSession(session);
+    assertThat(cmd.suggestArgument(null)).isEmpty();
+  }
+
+  @Test
+  void suggestArgumentReturnsEmptyOnException() {
+    ThrowingCommand cmd = new ThrowingCommand();
+    cmd.setSession(session);
+    assertThat(cmd.suggestArgument(null)).isEmpty();
+  }
+
+  @Test
+  void suggestOptionReturnsEmptyWhenPartialValueIsNonNull() {
+    SelfRecordingCommand cmd = new SelfRecordingCommand(new java.util.ArrayList<>());
+    cmd.setSession(session);
+    assertThat(cmd.suggestOption("x", "partial")).isEmpty();
+  }
+
+  @Test
+  void suggestOptionCallsDoSuggestOption() {
+    SelfRecordingCommand cmd = new SelfRecordingCommand(new java.util.ArrayList<>());
+    cmd.setSession(session);
+    assertThat(cmd.suggestOption("x", null)).isEmpty();
+  }
+
+  @Test
+  void suggestOptionReturnsEmptyOnException() {
+    ThrowingCommand cmd = new ThrowingCommand();
+    cmd.setSession(session);
+    assertThat(cmd.suggestOption("x", null)).isEmpty();
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/SessionTest.java
+++ b/src/test/java/sh/jmx/jmxsh/SessionTest.java
@@ -1,7 +1,6 @@
 package sh.jmx.jmxsh;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.io.Writer;
 import java.util.Map;
@@ -38,7 +37,7 @@ class SessionTest {
   @Test
   void connect() throws Exception {
     session.connect(SyntaxUtils.getUrl("localhost:9991", null), null);
-    Connection con = session.getConnection();
-    assertThat(con.url()).hasToString("service:jmx:rmi:///jndi/rmi://localhost:9991/jmxrmi");
+    Connection connection = session.getConnection();
+    assertThat(connection.url()).hasToString("service:jmx:rmi:///jndi/rmi://localhost:9991/jmxrmi");
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cc/CommandCenterTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/CommandCenterTest.java
@@ -6,7 +6,6 @@ import static sh.jmx.jmxsh.cc.CommandCenter.ESCAPE_CHAR_REGEX;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/sh/jmx/jmxsh/cc/HelpCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/HelpCommandTest.java
@@ -10,7 +10,6 @@ import java.beans.IntrospectionException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 

--- a/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
@@ -92,7 +92,7 @@ class BeanCommandTest {
   void executeWithInvalidBean() throws Exception {
     command.setBean("blablabla");
     command.setSession(session);
-    assertThatThrownBy(() -> command.execute()).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(command::execute).isInstanceOf(IllegalArgumentException.class);
   }
 
   /**

--- a/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
@@ -155,4 +155,36 @@ class BeanCommandTest {
     setBeanAndVerify(
         "attr.name_1-1=a.b", "domain_name.with-dash", "domain_name.with-dash:attr.name_1-1=a.b");
   }
+
+  @Test
+  void suggestOptionWithUnknownOption() {
+    command.setSession(session);
+    assertThat(command.suggestOption("x", null)).isEmpty();
+  }
+
+  @Test
+  void executeWhenColonBeanNotFound() throws Exception {
+    command.setBean("some:type=Thing");
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.getServerConnection()).thenReturn(con);
+    when(con.getMBeanInfo(new ObjectName("some:type=Thing")))
+        .thenThrow(new javax.management.InstanceNotFoundException("not found"));
+    // domain is null → triggers IAE about specifying domain
+    command.setSession(session);
+    assertThatThrownBy(command::execute).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please specify domain");
+  }
+
+  @Test
+  void executeWhenBeanNotFoundInDomain() throws Exception {
+    command.setBean("type=Thing");
+    when(session.getDomain()).thenReturn("mydomain");
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.getServerConnection()).thenReturn(con);
+    when(con.getMBeanInfo(new ObjectName("mydomain:type=Thing")))
+        .thenThrow(new javax.management.InstanceNotFoundException("not found"));
+    command.setSession(session);
+    assertThatThrownBy(command::execute).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("isn't valid");
+  }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/BeansCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/BeansCommandTest.java
@@ -41,8 +41,8 @@ class BeansCommandTest {
     writer = new StringWriter();
     command = new BeansCommand();
     lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
-    when(session.getConnection()).thenReturn(connection);
-    when(connection.getServerConnection()).thenReturn(conn);
+    lenient().when(session.getConnection()).thenReturn(connection);
+    lenient().when(connection.getServerConnection()).thenReturn(conn);
   }
 
   /**
@@ -113,5 +113,11 @@ class BeansCommandTest {
     command.setSession(session);
     command.execute();
     assertThat(writer).hasToString("a:type=1" + EOL + "a:type=2" + EOL + "b:type=1" + EOL);
+  }
+
+  @Test
+  void suggestOptionWithUnknownOption() {
+    command.setSession(session);
+    assertThat(command.suggestOption("x", null)).isEmpty();
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/BeansCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/BeansCommandTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 

--- a/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,8 +99,7 @@ class GetCommandTest {
         nestedExpectedValue = support.get(attributePath[1]);
       }
 
-      assertThat(writer.toString())
-          .isEqualTo(
+      assertThat(writer).hasToString(
               nestedExpectedValue.toString()
                   + delimiter
                   + (singleLine ? "" : System.lineSeparator()));

--- a/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
@@ -160,4 +160,30 @@ class GetCommandTest {
   void executeForSingleLineOutput() {
     getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "");
   }
+
+  @Test
+  void suggestArgumentWithNoBean() {
+    command.setSession(session);
+    assertThat(command.suggestArgument(null)).isEmpty();
+  }
+
+  @Test
+  void suggestOptionWithDomain() throws Exception {
+    when(con.getDomains()).thenReturn(new String[] {"a", "b"});
+    command.setSession(session);
+    assertThat(command.suggestOption("d", null)).containsExactly("a", "b");
+  }
+
+  @Test
+  void suggestOptionWithBean() throws Exception {
+    when(con.queryNames(null, null)).thenReturn(java.util.Set.of());
+    command.setSession(session);
+    assertThat(command.suggestOption("b", null)).isEmpty();
+  }
+
+  @Test
+  void suggestOptionUnknown() {
+    command.setSession(session);
+    assertThat(command.suggestOption("x", null)).isEmpty();
+  }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/OpenCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/OpenCommandTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.io.StringWriter;
 
 import javax.management.remote.JMXServiceURL;

--- a/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.management.MBeanInfo;

--- a/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
@@ -103,4 +103,10 @@ class RunCommandTest {
         .invoke(new ObjectName("a:type=x"), "exe", new Object[] {33}, new String[] {"int"});
     assertThat(writer.toString().trim()).isEqualTo("bingo-string");
   }
+
+  @Test
+  void suggestArgumentWithNoBean() {
+    command.setSession(session);
+    assertThat(command.suggestArgument(null)).isEmpty();
+  }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/SetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/SetCommandTest.java
@@ -115,4 +115,10 @@ class SetCommandTest {
   void executeWithQuotedNegativeNumber() {
     setValueAndVerify("\"-2\"", "int", -2);
   }
+
+  @Test
+  void suggestArgumentWithNoBean() {
+    command.setSession(session);
+    assertThat(command.suggestArgument(null)).isEmpty();
+  }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/SetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/SetCommandTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/src/test/java/sh/jmx/jmxsh/cmd/WatchCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/WatchCommandTest.java
@@ -1,0 +1,30 @@
+package sh.jmx.jmxsh.cmd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import sh.jmx.jmxsh.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WatchCommandTest {
+
+  @Mock
+  private Session session;
+
+  private WatchCommand command;
+
+  @BeforeEach
+  void setUp() {
+    command = new WatchCommand();
+  }
+
+  @Test
+  void suggestArgumentWithNoBean() {
+    command.setSession(session);
+    assertThat(command.suggestArgument(null)).isEmpty();
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/e2e/JmxshProcessHelper.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/JmxshProcessHelper.java
@@ -83,7 +83,7 @@ public class JmxshProcessHelper implements AutoCloseable {
   public String readAllOutput(Duration timeout) throws IOException {
     try {
       process.getOutputStream().close();
-    } catch (IOException ignored) {
+    } catch (IOException _) {
       // stdin may already be closed
     }
 
@@ -125,7 +125,7 @@ public class JmxshProcessHelper implements AutoCloseable {
     process.destroyForcibly();
     try {
       process.waitFor(5, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
     }
   }

--- a/src/test/java/sh/jmx/jmxsh/e2e/TargetJmxmpProcess.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/TargetJmxmpProcess.java
@@ -94,7 +94,7 @@ public class TargetJmxmpProcess implements AutoCloseable {
                   }
                 }
                 return false;
-              } catch (IOException e) {
+              } catch (IOException _) {
                 return false;
               }
             });
@@ -103,7 +103,7 @@ public class TargetJmxmpProcess implements AutoCloseable {
       if (!ready) {
         throw new IllegalStateException("JMXMP target JVM exited without printing READY");
       }
-    } catch (TimeoutException e) {
+    } catch (TimeoutException _) {
       throw new IllegalStateException(
           "JMXMP target JVM did not become ready within " + timeout.toSeconds() + " seconds");
     } catch (InterruptedException e) {
@@ -124,7 +124,7 @@ public class TargetJmxmpProcess implements AutoCloseable {
     process.destroyForcibly();
     try {
       process.waitFor(5, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
     }
   }

--- a/src/test/java/sh/jmx/jmxsh/e2e/TargetJvmProcess.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/TargetJvmProcess.java
@@ -99,7 +99,7 @@ public class TargetJvmProcess implements AutoCloseable {
                   }
                 }
                 return false;
-              } catch (IOException e) {
+              } catch (IOException _) {
                 return false;
               }
             });
@@ -108,7 +108,7 @@ public class TargetJvmProcess implements AutoCloseable {
       if (!ready) {
         throw new IllegalStateException("Target JVM exited without printing READY");
       }
-    } catch (TimeoutException e) {
+    } catch (TimeoutException _) {
       throw new IllegalStateException(
           "Target JVM did not become ready within " + timeout.toSeconds() + " seconds");
     } catch (InterruptedException e) {
@@ -134,7 +134,7 @@ public class TargetJvmProcess implements AutoCloseable {
     process.destroyForcibly();
     try {
       process.waitFor(5, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
     }
   }

--- a/src/test/java/sh/jmx/jmxsh/integration/AttributeReadWriteIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/AttributeReadWriteIT.java
@@ -66,8 +66,9 @@ class AttributeReadWriteIT {
     assertThat(cc.execute("bean test:type=TestMBean")).isTrue();
     assertThat(cc.execute("get *")).isTrue();
     String result = resultWriter.toString();
-    assertThat(result).as("Expected output to contain 'Name', got: " + result).contains("Name");
-    assertThat(result).as("Expected output to contain 'Count', got: " + result).contains("Count");
+    assertThat(result)
+        .as("Expected output to contain 'Name', got: " + result).contains("Name")
+        .as("Expected output to contain 'Count', got: " + result).contains("Count");
   }
 
   @Test
@@ -104,10 +105,9 @@ class AttributeReadWriteIT {
     assertThat(cc.execute("open " + jmxServer.getConnectionUrl())).isTrue();
     assertThat(cc.execute("get -s -b test:type=TestMBean Name")).isTrue();
     String result = resultWriter.toString().trim();
-    assertThat(result).as("Expected simple format value 'default', got: " + result).contains("default");
     assertThat(result)
-        .as("Simple format should not contain 'Name =', got: " + result)
-        .doesNotContain("Name =");
+        .as("Expected simple format value 'default', got: " + result).contains("default")
+        .as("Simple format should not contain 'Name =', got: " + result).doesNotContain("Name =");
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/integration/CommandChainingIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/CommandChainingIT.java
@@ -48,13 +48,10 @@ class CommandChainingIT {
                 "open " + jmxServer.getConnectionUrl() + " && domains && beans -d test"))
         .isTrue();
     String result = resultWriter.toString();
-    assertThat(result).as("Expected 'test' domain in output, got: " + result).contains("test");
     assertThat(result)
-        .as("Expected 'JMImplementation' domain in output, got: " + result)
-        .contains("JMImplementation");
-    assertThat(result)
-        .as("Expected 'test:type=TestMBean' in output, got: " + result)
-        .contains("test:type=TestMBean");
+        .as("Expected 'test' domain in output, got: " + result).contains("test")
+        .as("Expected 'JMImplementation' domain in output, got: " + result).contains("JMImplementation")
+        .as("Expected 'test:type=TestMBean' in output, got: " + result).contains("test:type=TestMBean");
   }
 
   @Test
@@ -69,7 +66,7 @@ class CommandChainingIT {
   @Test
   void testFullLineComment() {
     assertThat(cc.execute("# this is a comment")).isTrue();
-    assertThat(resultWriter.toString()).as("Full-line comment should produce no output").isEqualTo("");
+    assertThat(resultWriter.toString()).as("Full-line comment should produce no output").isEmpty();
   }
 
   @Test
@@ -87,6 +84,6 @@ class CommandChainingIT {
   @Test
   void testEmptyCommand() {
     assertThat(cc.execute("")).as("Empty command should succeed").isTrue();
-    assertThat(resultWriter.toString()).as("Empty command should produce no output").isEqualTo("");
+    assertThat(resultWriter.toString()).as("Empty command should produce no output").isEmpty();
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/integration/DomainBeanNavigationIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/DomainBeanNavigationIT.java
@@ -21,7 +21,7 @@ class DomainBeanNavigationIT {
   private StringWriter messageWriter;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     resultWriter = new StringWriter();
     messageWriter = new StringWriter();
     cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);

--- a/src/test/java/sh/jmx/jmxsh/integration/DomainBeanNavigationIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/DomainBeanNavigationIT.java
@@ -38,10 +38,9 @@ class DomainBeanNavigationIT {
     resultWriter.getBuffer().setLength(0);
     assertThat(cc.execute("domains")).isTrue();
     String result = resultWriter.toString();
-    assertThat(result).as("Expected 'test' domain, got: " + result).contains("test");
     assertThat(result)
-        .as("Expected 'JMImplementation' domain, got: " + result)
-        .contains("JMImplementation");
+        .as("Expected 'test' domain, got: " + result).contains("test")
+        .as("Expected 'JMImplementation' domain, got: " + result).contains("JMImplementation");
   }
 
   @Test
@@ -92,11 +91,12 @@ class DomainBeanNavigationIT {
     assertThat(cc.execute("info")).isTrue();
     String result = resultWriter.toString();
     // Verify attributes are listed
-    assertThat(result).as("Expected attribute 'Name' in info, got: " + result).contains("Name");
-    assertThat(result).as("Expected attribute 'Count' in info, got: " + result).contains("Count");
-    // Verify operations are listed
-    assertThat(result).as("Expected operation 'echo' in info, got: " + result).contains("echo");
-    assertThat(result).as("Expected operation 'add' in info, got: " + result).contains("add");
-    assertThat(result).as("Expected operation 'reset' in info, got: " + result).contains("reset");
+    assertThat(result)
+        .as("Expected attribute 'Name' in info, got: " + result).contains("Name")
+        .as("Expected attribute 'Count' in info, got: " + result).contains("Count")
+        // Verify operations are listed
+        .as("Expected operation 'echo' in info, got: " + result).contains("echo")
+        .as("Expected operation 'add' in info, got: " + result).contains("add")
+        .as("Expected operation 'reset' in info, got: " + result).contains("reset");
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/integration/EmbeddedJmxServer.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/EmbeddedJmxServer.java
@@ -65,7 +65,7 @@ public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
         Registry reg = LocateRegistry.createRegistry(candidatePort);
         this.port = candidatePort;
         return reg;
-      } catch (ExportException e) {
+      } catch (ExportException _) {
         // Port already in use, retry with a different port
       }
     }

--- a/src/test/java/sh/jmx/jmxsh/integration/EmbeddedJmxmpServer.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/EmbeddedJmxmpServer.java
@@ -49,7 +49,7 @@ public class EmbeddedJmxmpServer implements BeforeAllCallback, AfterAllCallback 
         connectorServer.start();
         this.port = candidatePort;
         return;
-      } catch (Exception e) {
+      } catch (Exception _) {
         // Port already in use or bind failure, retry with a different port
       }
     }

--- a/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
@@ -22,7 +22,7 @@ class VerboseLevelIT {
   private StringWriter messageWriter;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     resultWriter = new StringWriter();
     messageWriter = new StringWriter();
     cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);

--- a/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
@@ -39,9 +39,8 @@ class VerboseLevelIT {
     assertThat(cc.execute("open " + jmxServer.getConnectionUrl())).isTrue();
     String messages = messageWriter.toString();
     assertThat(messages)
-        .as("Expected '#' prefixed messages in BRIEF mode, got: " + messages)
-        .contains("#");
-    assertThat(messages).as("Expected connection message, got: " + messages).contains("Connection to");
+        .as("Expected '#' prefixed messages in BRIEF mode, got: " + messages).contains("#")
+        .as("Expected connection message, got: " + messages).contains("Connection to");
   }
 
   @Test
@@ -66,10 +65,7 @@ class VerboseLevelIT {
     assertThat(cc.execute("get Name")).isFalse();
     String messages = messageWriter.toString();
     assertThat(messages)
-        .as("Expected '#' prefixed error in BRIEF mode, got: " + messages)
-        .contains("#");
-    assertThat(messages)
-        .as("Expected no stack trace in BRIEF mode, got: " + messages)
-        .doesNotContain("\tat ");
+        .as("Expected '#' prefixed error in BRIEF mode, got: " + messages).contains("#")
+        .as("Expected no stack trace in BRIEF mode, got: " + messages).doesNotContain("\tat ");
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/io/ValueOutputFormatTest.java
+++ b/src/test/java/sh/jmx/jmxsh/io/ValueOutputFormatTest.java
@@ -3,7 +3,6 @@ package sh.jmx.jmxsh.io;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/sh/jmx/jmxsh/utils/AppConfigTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/AppConfigTest.java
@@ -5,9 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AppConfigTest {
 
@@ -17,35 +21,20 @@ class AppConfigTest {
     assertThat(config.isLoggingFileEnabled()).isFalse();
   }
 
-  @Test
-  void loggingFileEnabledWhenSetToTrue(@TempDir Path dir) throws IOException {
-    Path configFile = dir.resolve("config.properties");
-    Files.writeString(configFile, "logging.file.enabled=true\n");
-    AppConfig config = AppConfig.load(configFile);
-    assertThat(config.isLoggingFileEnabled()).isTrue();
+  static Stream<Arguments> loggingFileEnabledCases() {
+    return Stream.of(
+        Arguments.of("logging.file.enabled=true\n", true),
+        Arguments.of("logging.file.enabled=false\n", false),
+        Arguments.of("logging.file.enabled=yes\n", false),
+        Arguments.of("some.other.key=value\n", false));
   }
 
-  @Test
-  void loggingFileDisabledWhenSetToFalse(@TempDir Path dir) throws IOException {
+  @ParameterizedTest
+  @MethodSource("loggingFileEnabledCases")
+  void loggingFileEnabled(String content, boolean expected, @TempDir Path dir) throws IOException {
     Path configFile = dir.resolve("config.properties");
-    Files.writeString(configFile, "logging.file.enabled=false\n");
+    Files.writeString(configFile, content);
     AppConfig config = AppConfig.load(configFile);
-    assertThat(config.isLoggingFileEnabled()).isFalse();
-  }
-
-  @Test
-  void malformedValueFallsBackToDefault(@TempDir Path dir) throws IOException {
-    Path configFile = dir.resolve("config.properties");
-    Files.writeString(configFile, "logging.file.enabled=yes\n");
-    AppConfig config = AppConfig.load(configFile);
-    assertThat(config.isLoggingFileEnabled()).isFalse();
-  }
-
-  @Test
-  void missingKeyFallsBackToDefault(@TempDir Path dir) throws IOException {
-    Path configFile = dir.resolve("config.properties");
-    Files.writeString(configFile, "some.other.key=value\n");
-    AppConfig config = AppConfig.load(configFile);
-    assertThat(config.isLoggingFileEnabled()).isFalse();
+    assertThat(config.isLoggingFileEnabled()).isEqualTo(expected);
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/utils/ValueFormatTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/ValueFormatTest.java
@@ -11,7 +11,7 @@ class ValueFormatTest {
     assertThat(ValueFormat.parseValue("null")).isNull();
     assertThat(ValueFormat.parseValue(null)).isNull();
     assertThat(ValueFormat.parseValue("")).isNull();
-    assertThat(ValueFormat.parseValue("\"\"")).isEqualTo("");
+    assertThat(ValueFormat.parseValue("\"\"")).isEmpty();
     assertThat(ValueFormat.parseValue("abc")).isEqualTo("abc");
     assertThat(ValueFormat.parseValue("\"abc\"")).isEqualTo("abc");
     assertThat(ValueFormat.parseValue("ab c")).isEqualTo("ab c");

--- a/src/test/java/sh/jmx/jmxsh/utils/ValueFormatTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/ValueFormatTest.java
@@ -18,4 +18,9 @@ class ValueFormatTest {
     assertThat(ValueFormat.parseValue("ab\\nc")).isEqualTo("ab\nc");
     assertThat(ValueFormat.parseValue("ab\\u3160c")).isEqualTo("ab\u3160c");
   }
+
+  @Test
+  void parseWithInvalidUnicodeEscape() {
+    assertThat(ValueFormat.parseValue("ab\\uGGGGc")).isEqualTo("ab\\uGGGGc");
+  }
 }


### PR DESCRIPTION
## Summary

Fixes 12 SonarQube rules across 34 files. All changes were reviewed interactively and tests pass.

### Fixed rules

| Rule | Description |
|------|-------------|
| S1128 | Remove unused imports |
| S1612 | Replace lambdas with method references |
| S2093 | Use try-with-resources (+ `CommandOutput extends AutoCloseable`) |
| S3252 | Use `import static` for `ROOT_LOGGER_NAME` |
| S1130 | Remove redundant `throws IOException` from constructor |
| S1117 | Rename shadowed local variable in test |
| S7467 | Replace unused catch variables with `_` (Java 22+) |
| S1168 | Replace `return null` in collection methods with `List.of()` |
| S108  | Add explanatory comments to empty catch blocks |
| S5838 | Use `isEmpty()` / `hasToString()` assertion helpers |
| S5853 | Chain multiple assertions on the same subject |
| S5976 | Parameterize `AppConfigTest` with `@ParameterizedTest` |

### Skipped rules
S1172, S2699, S106, S3776/S6541, S127, S135, S5998/S6035, S6548 — skipped by choice (API contracts, intentional design, or large refactors).