### PR TITLE
chore: dispatch formula update to homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: nyg/homebrew-jmxsh
+          repository: nyg/homebrew-tap
           event-type: update-formula
           client-payload: >-
             {


### PR DESCRIPTION
Redirect the Homebrew formula update dispatch from the dedicated `homebrew-jmxsh` tap to the new shared `homebrew-tap` repo.