### PR TITLE
fix(cmd): suppress welcome message when using -n flag

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -153,7 +153,7 @@ public class CliMain {
                 env.isEmpty() ? null : env);
           }
           commandCenter.setOutputMode(outputMode);
-          if (!options.isQuiet()) {
+          if (!options.isQuiet() && !options.isNonInteractive()) {
             output.printMessage("Welcome to jmx.sh, type \"help\" for available commands.");
           }
           String line;


### PR DESCRIPTION
## Problem

When running `jmxsh -n`, the welcome message `Welcome to jmx.sh, type "help" for available commands.` was still printed, even though `-n` indicates non-interactive (scripting) mode.

## Fix

Add `!options.isNonInteractive()` to the guard condition for printing the welcome message. The message is now suppressed when either `-n` or `-q` is active.