### PR TITLE
feat(cmd): deduplicate JLine command history in-session and on disk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,6 @@
                   <manifestEntries>
                     <Implementation-Title>jmxsh</Implementation-Title>
                     <Implementation-Version>${project.version}</Implementation-Version>
-                    <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
                   </manifestEntries>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
                   <manifestEntries>
                     <Implementation-Title>jmxsh</Implementation-Title>
                     <Implementation-Version>${project.version}</Implementation-Version>
+                    <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
                   </manifestEntries>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -101,7 +101,7 @@ public class CliMain {
           input = new InputStreamCommandInput(System.in);
         } else {
           DeduplicatingHistory history = new DeduplicatingHistory();
-          Terminal terminal = TerminalBuilder.builder().graphemeCluster(false).build();
+          Terminal terminal = TerminalBuilder.builder().ffm(false).graphemeCluster(false).build();
           LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().terminal(terminal).history(history).build();
           Path historyPath = XdgDirectories.INSTANCE.getHistoryFile();
           migrateHistory(XdgDirectories.INSTANCE.getLegacyHistoryFile(), historyPath);

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -28,6 +28,8 @@ import sh.jmx.jmxsh.utils.XdgDirectories;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.impl.LineReaderImpl;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -99,7 +101,8 @@ public class CliMain {
           input = new InputStreamCommandInput(System.in);
         } else {
           DeduplicatingHistory history = new DeduplicatingHistory();
-          LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().history(history).build();
+          Terminal terminal = TerminalBuilder.builder().graphemeCluster(false).build();
+          LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().terminal(terminal).history(history).build();
           Path historyPath = XdgDirectories.INSTANCE.getHistoryFile();
           migrateHistory(XdgDirectories.INSTANCE.getLegacyHistoryFile(), historyPath);
           Files.createDirectories(historyPath.getParent());

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -101,7 +101,7 @@ public class CliMain {
           input = new InputStreamCommandInput(System.in);
         } else {
           DeduplicatingHistory history = new DeduplicatingHistory();
-          Terminal terminal = TerminalBuilder.builder().ffm(false).graphemeCluster(false).build();
+          Terminal terminal = TerminalBuilder.builder().graphemeCluster(false).build();
           LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().terminal(terminal).history(history).build();
           Path historyPath = XdgDirectories.INSTANCE.getHistoryFile();
           migrateHistory(XdgDirectories.INSTANCE.getLegacyHistoryFile(), historyPath);

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -25,7 +25,6 @@ import sh.jmx.jmxsh.io.PrintStreamCommandOutput;
 import sh.jmx.jmxsh.io.OutputMode;
 import sh.jmx.jmxsh.utils.AppConfig;
 import sh.jmx.jmxsh.utils.XdgDirectories;
-import org.jline.reader.History;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.impl.LineReaderImpl;
@@ -99,13 +98,13 @@ public class CliMain {
         if (options.isNonInteractive()) {
           input = new InputStreamCommandInput(System.in);
         } else {
-          LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().build();
+          DeduplicatingHistory history = new DeduplicatingHistory();
+          LineReaderImpl consoleReader = (LineReaderImpl) LineReaderBuilder.builder().history(history).build();
           Path historyPath = XdgDirectories.INSTANCE.getHistoryFile();
           migrateHistory(XdgDirectories.INSTANCE.getLegacyHistoryFile(), historyPath);
           Files.createDirectories(historyPath.getParent());
           consoleReader.setVariable(LineReader.HISTORY_FILE, historyPath);
-          History history = consoleReader.getHistory();
-          history.load();
+          history.attach(consoleReader);
           Runtime.getRuntime()
               .addShutdownHook(
                   new Thread(

--- a/src/main/java/sh/jmx/jmxsh/boot/DeduplicatingHistory.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/DeduplicatingHistory.java
@@ -1,0 +1,98 @@
+package sh.jmx.jmxsh.boot;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ListIterator;
+
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.impl.ReaderUtils;
+import org.jline.reader.impl.history.DefaultHistory;
+
+/**
+ * A history implementation that deduplicates entries both in-memory and on disk.
+ *
+ * <p>When a command is added that already exists in the history, the old entry is removed
+ * and the new entry is appended — ensuring each command appears at most once (most recent
+ * position wins). This applies both during an active session (Up/Down arrow browsing) and
+ * in the history file persisted to disk.
+ */
+public class DeduplicatingHistory extends DefaultHistory {
+
+  private LineReader lineReader;
+
+  @Override
+  public void attach(LineReader reader) {
+    this.lineReader = reader;
+    super.attach(reader);
+  }
+
+  /**
+   * Adds an entry and removes any previous occurrence of the same line.
+   *
+   * <p>All normal JLine filters (HISTORY_IGNORE_SPACE, HISTORY_IGNORE_DUPS, HISTORY_IGNORE
+   * patterns, etc.) are applied by {@code super.add()} first. Only if an entry was actually
+   * added do we scan and remove earlier occurrences.
+   *
+   * <p>{@link #moveToEnd()} is called after removal to keep the navigation cursor consistent
+   * with the new list size.
+   */
+  @Override
+  public void add(Instant time, String line) {
+    int sizeBefore = size();
+    super.add(time, line);
+    if (size() > sizeBefore) {
+      int addedIndex = last();
+      String addedLine = get(addedIndex);
+      ListIterator<History.Entry> it = iterator(first());
+      while (it.hasNext()) {
+        History.Entry e = it.next();
+        if (e.index() != addedIndex && e.line().equals(addedLine)) {
+          it.remove();
+        }
+      }
+      moveToEnd();
+    }
+  }
+
+  /**
+   * Saves history with a full file rewrite to avoid the {@code lastLoaded} issue.
+   *
+   * <p>When {@link #add} removes a loaded entry from the in-memory list, the superclass
+   * {@code save()} would compute an empty append range and silently drop the newly-added
+   * command. We bypass this by calling {@link #write write(null, false)} which rewrites
+   * all entries from scratch, then {@link #trimHistory} to deduplicate any pre-existing
+   * duplicates and reset internal file metadata.
+   */
+  @Override
+  public void save() throws IOException {
+    if (lineReader == null) {
+      super.save();
+      return;
+    }
+    Path path = resolvePath(lineReader.getVariable(LineReader.HISTORY_FILE));
+    if (path == null) {
+      super.save();
+      return;
+    }
+    write(null, false);
+    if (Files.exists(path) && Files.size(path) > 0) {
+      int max = ReaderUtils.getInt(lineReader, LineReader.HISTORY_FILE_SIZE, DEFAULT_HISTORY_FILE_SIZE);
+      trimHistory(path, max);
+    }
+  }
+
+  private static Path resolvePath(Object obj) {
+    if (obj instanceof Path p) {
+      return p;
+    } else if (obj instanceof File f) {
+      return f.toPath();
+    } else if (obj != null) {
+      return Path.of(obj.toString());
+    }
+    return null;
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
+++ b/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
@@ -174,7 +174,7 @@ class DeduplicatingHistoryTest {
   void saveIsNoopWhenHistoryNotAttached() throws IOException {
     DeduplicatingHistory h = new DeduplicatingHistory();
     h.save(); // must not throw
-    assertThat(h.size()).isEqualTo(0);
+    assertThat(h.size()).isZero();
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
+++ b/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jline.reader.History;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.terminal.Terminal;
@@ -173,14 +172,13 @@ class DeduplicatingHistoryTest {
 
   @Test
   void saveIsNoopWhenHistoryNotAttached() throws IOException {
-    // DeduplicatingHistory with no reader attached → falls back to super.save()
     DeduplicatingHistory h = new DeduplicatingHistory();
     h.save(); // must not throw
+    assertThat(h.size()).isEqualTo(0);
   }
 
   @Test
   void saveIsNoopWhenNoHistoryFileConfigured() throws IOException {
-    // Attach reader but leave HISTORY_FILE variable unset → path resolves to null
     DeduplicatingHistory h = new DeduplicatingHistory();
     Terminal t = TerminalBuilder.builder().dumb(true).build();
     try {
@@ -188,6 +186,7 @@ class DeduplicatingHistoryTest {
       h.attach(r); // HISTORY_FILE not set → getVariable returns null
       h.add("cmd1");
       h.save(); // must not throw
+      assertThat(h.size()).isEqualTo(1);
     } finally {
       t.close();
     }

--- a/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
+++ b/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
@@ -1,0 +1,178 @@
+package sh.jmx.jmxsh.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DeduplicatingHistoryTest {
+
+  @TempDir
+  Path tmpDir;
+
+  private Terminal terminal;
+  private DeduplicatingHistory history;
+  private LineReader reader;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    terminal = TerminalBuilder.builder().dumb(true).build();
+    history = new DeduplicatingHistory();
+    reader = LineReaderBuilder.builder().terminal(terminal).history(history).build();
+    reader.setVariable(LineReader.HISTORY_FILE, tmpDir.resolve("history"));
+    reader.option(LineReader.Option.HISTORY_TIMESTAMPED, false);
+    history.attach(reader);
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    terminal.close();
+  }
+
+  // -- in-session (add) deduplication -----------------------------------------
+
+  @Test
+  void addRemovesEarlierOccurrenceOfSameLine() {
+    history.add("cmd1");
+    history.add("cmd2");
+    history.add("cmd1"); // duplicate of first entry
+
+    assertThat(lines()).containsExactly("cmd2", "cmd1");
+  }
+
+  @Test
+  void addKeepsMostRecentEntry() {
+    history.add("cmd1");
+    history.add("cmd2");
+    history.add("cmd1");
+
+    assertThat(lines().getLast()).isEqualTo("cmd1");
+  }
+
+  @Test
+  void addDoesNotDeduplicateDistinctLines() {
+    history.add("cmd1");
+    history.add("cmd2");
+    history.add("cmd3");
+
+    assertThat(lines()).containsExactly("cmd1", "cmd2", "cmd3");
+  }
+
+  @Test
+  void addSingleEntryLeavesHistorySizeOne() {
+    history.add("cmd1");
+
+    assertThat(history.size()).isEqualTo(1);
+  }
+
+  @Test
+  void addConsecutiveDuplicateIsHandledCorrectly() {
+    history.add("cmd1");
+    history.add("cmd1");
+
+    // HISTORY_IGNORE_DUPS prevents second add, so we end up with just one entry
+    assertThat(lines()).containsExactly("cmd1");
+  }
+
+  @Test
+  void addMultipleDuplicatesRemovesAllPrior() {
+    history.add("a");
+    history.add("b");
+    history.add("a");
+    history.add("c");
+    history.add("a");
+
+    // Only the most recent "a" should remain; earlier occurrences removed
+    assertThat(lines()).containsExactly("b", "c", "a");
+  }
+
+  // -- file persistence (save) deduplication ----------------------------------
+
+  @Test
+  void saveDeduplicatesFileWithPreExistingDuplicates(@TempDir Path dir) throws IOException {
+    Path file = dir.resolve("history");
+    // Write a file with duplicates simulating a previous session
+    Files.writeString(file, "cmd1\ncmd2\ncmd1\n");
+
+    DeduplicatingHistory h = new DeduplicatingHistory();
+    Terminal t = TerminalBuilder.builder().dumb(true).build();
+    try {
+      LineReader r = LineReaderBuilder.builder().terminal(t).history(h).build();
+      r.setVariable(LineReader.HISTORY_FILE, file);
+      r.option(LineReader.Option.HISTORY_TIMESTAMPED, false);
+      h.attach(r); // load() is called by attach; items = [cmd1, cmd2, cmd1]
+      h.save();
+
+      List<String> saved = Files.readAllLines(file);
+      assertThat(saved).containsExactly("cmd2", "cmd1");
+    } finally {
+      t.close();
+    }
+  }
+
+  @Test
+  void saveSafeWhenFileDoesNotExistYet() throws IOException {
+    // No history file created yet — save() should not throw
+    history.add("cmd1");
+    history.save();
+
+    Path file = (Path) reader.getVariable(LineReader.HISTORY_FILE);
+    assertThat(Files.readAllLines(file)).containsExactly("cmd1");
+  }
+
+  @Test
+  void saveWritesAllInSessionEntriesToFile() throws IOException {
+    history.add("cmd1");
+    history.add("cmd2");
+    history.add("cmd3");
+    history.save();
+
+    Path file = (Path) reader.getVariable(LineReader.HISTORY_FILE);
+    assertThat(Files.readAllLines(file)).containsExactly("cmd1", "cmd2", "cmd3");
+  }
+
+  @Test
+  void saveDeduplicatesAfterLoadPlusInSessionAdd(@TempDir Path dir) throws IOException {
+    Path file = dir.resolve("history");
+    Files.writeString(file, "old\n");
+
+    DeduplicatingHistory h = new DeduplicatingHistory();
+    Terminal t = TerminalBuilder.builder().dumb(true).build();
+    try {
+      LineReader r = LineReaderBuilder.builder().terminal(t).history(h).build();
+      r.setVariable(LineReader.HISTORY_FILE, file);
+      r.option(LineReader.Option.HISTORY_TIMESTAMPED, false);
+      h.attach(r); // loads "old" from file
+      h.add("old"); // duplicate of loaded entry — our add() removes the loaded one
+      h.save();
+
+      List<String> saved = Files.readAllLines(file);
+      // "old" should appear exactly once — in the most recent position
+      assertThat(saved).containsExactly("old");
+      assertThat(h.size()).isEqualTo(1);
+    } finally {
+      t.close();
+    }
+  }
+
+  // -- helpers -----------------------------------------------------------------
+
+  private List<String> lines() {
+    List<String> result = new ArrayList<>();
+    history.iterator(history.first()).forEachRemaining(e -> result.add(e.line()));
+    return result;
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
+++ b/src/test/java/sh/jmx/jmxsh/boot/DeduplicatingHistoryTest.java
@@ -2,6 +2,7 @@ package sh.jmx.jmxsh.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -163,6 +164,68 @@ class DeduplicatingHistoryTest {
       // "old" should appear exactly once — in the most recent position
       assertThat(saved).containsExactly("old");
       assertThat(h.size()).isEqualTo(1);
+    } finally {
+      t.close();
+    }
+  }
+
+  // -- save() fallback paths ---------------------------------------------------
+
+  @Test
+  void saveIsNoopWhenHistoryNotAttached() throws IOException {
+    // DeduplicatingHistory with no reader attached → falls back to super.save()
+    DeduplicatingHistory h = new DeduplicatingHistory();
+    h.save(); // must not throw
+  }
+
+  @Test
+  void saveIsNoopWhenNoHistoryFileConfigured() throws IOException {
+    // Attach reader but leave HISTORY_FILE variable unset → path resolves to null
+    DeduplicatingHistory h = new DeduplicatingHistory();
+    Terminal t = TerminalBuilder.builder().dumb(true).build();
+    try {
+      LineReader r = LineReaderBuilder.builder().terminal(t).history(h).build();
+      h.attach(r); // HISTORY_FILE not set → getVariable returns null
+      h.add("cmd1");
+      h.save(); // must not throw
+    } finally {
+      t.close();
+    }
+  }
+
+  @Test
+  void saveAcceptsFileObjectAsHistoryPath(@TempDir Path dir) throws IOException {
+    Path file = dir.resolve("history");
+    DeduplicatingHistory h = new DeduplicatingHistory();
+    Terminal t = TerminalBuilder.builder().dumb(true).build();
+    try {
+      LineReader r = LineReaderBuilder.builder().terminal(t).history(h).build();
+      r.setVariable(LineReader.HISTORY_FILE, new File(file.toString())); // java.io.File, not Path
+      r.option(LineReader.Option.HISTORY_TIMESTAMPED, false);
+      h.attach(r);
+      h.add("cmd1");
+      h.save();
+
+      assertThat(Files.readAllLines(file)).containsExactly("cmd1");
+    } finally {
+      t.close();
+    }
+  }
+
+  @Test
+  void saveAcceptsStringAsHistoryPath(@TempDir Path dir) throws IOException {
+    Path file = dir.resolve("history");
+    DeduplicatingHistory h = new DeduplicatingHistory();
+    Terminal t = TerminalBuilder.builder().dumb(true).build();
+    try {
+      LineReader r = LineReaderBuilder.builder().terminal(t).history(h).build();
+      r.setVariable(LineReader.HISTORY_FILE, file.toString()); // String, not Path
+      r.option(LineReader.Option.HISTORY_TIMESTAMPED, false);
+      h.attach(r);
+      h.add("cmd1");
+      h.save();
+
+      assertThat(Files.readAllLines(file)).containsExactly("cmd1");
     } finally {
       t.close();
     }


### PR DESCRIPTION
## Summary

When a command is added that already exists in history, the old entry is removed and the new entry is appended at the end. Each command appears at most once — most recent position wins. This applies both during an active session (Up/Down arrow browsing) and in the history file on disk.

## Changes

### `DeduplicatingHistory` (new class)

Extends `DefaultHistory` with two overrides:

**`add()`** — after `super.add()` adds the new entry, scans all in-memory items via `iterator(first())` and removes any earlier entry with the same line. Calls `moveToEnd()` afterwards to keep the navigation cursor consistent with the new list size. Handles entries loaded from previous sessions as well as entries added in the current session.

**`save()`** — uses `write(null, false)` (full file rewrite) instead of the superclass append-only approach. This is necessary because `add()` may remove entries from the "loaded" section of the item list, which would cause `super.save()`'s append-only logic to silently drop the newly-added command. Follows with `trimHistory(path, max)` to deduplicate any duplicates from pre-existing file content and reset internal metadata.

**`attach()`** — captures the `LineReader` reference so `save()` can resolve the history file path and the `HISTORY_FILE_SIZE` limit. Also ensures `DefaultHistory.reader` is set before first use.

### `CliMain` (modified)

- Creates a `DeduplicatingHistory` instance and passes it to `LineReaderBuilder.builder().history(history).build()`
- Calls `history.attach(consoleReader)` explicitly after setting `HISTORY_FILE` to initialise the reader reference (in JLine 4.1.3, `setHistory()` does not call `attach()` — that only happens lazily when `readLine()` is first invoked)

### `DeduplicatingHistoryTest` (new test class)

10 tests covering in-session dedup via `add()`, multiple duplicates of the same command, file deduplication of pre-existing duplicates on save, save after load + in-session add (the `lastLoaded` edge case), and safe operation with missing file.