### PR TITLE
feat(io,cmd): configurable prompt, clean UX — remove # prefix, Ctrl+C, domain/bean sync

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import javax.management.remote.JMXConnector;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 
+import sh.jmx.jmxsh.Session;
 import sh.jmx.jmxsh.SyntaxUtils;
 import sh.jmx.jmxsh.cc.CommandCenter;
 import sh.jmx.jmxsh.cc.ConsoleCompleter;
@@ -24,6 +25,7 @@ import sh.jmx.jmxsh.io.JlineCommandInput;
 import sh.jmx.jmxsh.io.PrintStreamCommandOutput;
 import sh.jmx.jmxsh.io.OutputMode;
 import sh.jmx.jmxsh.utils.AppConfig;
+import sh.jmx.jmxsh.utils.PromptTemplate;
 import sh.jmx.jmxsh.utils.XdgDirectories;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -42,8 +44,6 @@ import picocli.CommandLine;
 @Slf4j
 public class CliMain {
   private static final PrintWriter STDOUT_WRITER = new PrintWriter(System.out, true);
-
-  private static final String COMMAND_PROMPT = "$> ";
 
   static void main(String[] args) {
     try {
@@ -95,6 +95,7 @@ public class CliMain {
       output = new FileCommandOutput(Path.of(options.getOutput()), options.isAppendToOutput());
     }
     try (output) {
+      Session[] sessionRef = {null};
       CommandInput input;
       if (CliMainOptions.STDIN.equals(options.getInput())) {
         if (options.isNonInteractive()) {
@@ -118,7 +119,9 @@ public class CliMain {
                           log.warn("failed to flush command history", e);
                         }
                       }));
-          input = new JlineCommandInput(consoleReader, COMMAND_PROMPT);
+          String promptTemplate = appConfig.getPrompt();
+          input = new JlineCommandInput(consoleReader,
+              () -> PromptTemplate.resolve(promptTemplate, sessionRef[0]));
         }
       } else {
         Path inputPath = Path.of(options.getInput());
@@ -131,6 +134,7 @@ public class CliMain {
         CommandCenter commandCenter = new CommandCenter(output, input);
         try {
           if (input instanceof JlineCommandInput commandInput) {
+            sessionRef[0] = commandCenter.getSession();
             commandInput
                 .getConsole()
                 .setCompleter(new ConsoleCompleter(commandCenter));

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -28,6 +28,7 @@ import sh.jmx.jmxsh.utils.AppConfig;
 import sh.jmx.jmxsh.utils.PromptTemplate;
 import sh.jmx.jmxsh.utils.XdgDirectories;
 import org.jline.reader.LineReader;
+import org.jline.reader.UserInterruptException;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.impl.LineReaderImpl;
 import org.jline.terminal.Terminal;
@@ -165,7 +166,16 @@ public class CliMain {
           String line;
           int exitCode = 0;
           int lineNumber = 0;
-          while ((line = input.readLine()) != null) {
+          while (true) {
+            try {
+              line = input.readLine();
+            } catch (UserInterruptException _) {
+              output.printMessage("Interrupted.");
+              break;
+            }
+            if (line == null) {
+              break;
+            }
             lineNumber++;
             if (!commandCenter.execute(line) && options.isExitOnFailure()) {
               exitCode = -lineNumber;

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -51,7 +51,7 @@ public class CliMain {
       System.exit(new CliMain().execute(args));
     } catch (Exception e) {
       String message = e.getMessage() != null ? e.getMessage() : e.toString();
-      System.err.println("# " + message);
+      System.err.println(message);
       log.error("Fatal error", e);
       System.exit(1);
     }

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -156,6 +156,10 @@ public class CommandCenter {
     return processManager;
   }
 
+  public Session getSession() {
+    return session;
+  }
+
   public boolean isClosed() {
     return session.isClosed();
   }

--- a/src/main/java/sh/jmx/jmxsh/cc/HelpCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/HelpCommand.java
@@ -24,14 +24,14 @@ public class HelpCommand extends sh.jmx.jmxsh.Command {
     Objects.requireNonNull(commandCenter, "Command center hasn't been set yet");
     if (argNames.isEmpty()) {
       List<String> commandNames = commandCenter.getCommandNames().stream().sorted().toList();
-      getSession().getOutput().printMessage("following commands are available to use:");
+      getSession().getOutput().printMessage("The following commands are available to use:");
       for (String commandName : commandNames) {
         sh.jmx.jmxsh.Command cmd =
             commandCenter.createCommand(commandName);
         CommandLine cl = new CommandLine(cmd);
         String[] desc = cl.getCommandSpec().usageMessage().description();
         String description = desc.length > 0 ? String.join(" ", desc) : "";
-        getSession().getOutput().println("%-8s - %s".formatted(commandName, description));
+        getSession().getOutput().println("%-11s - %s".formatted(commandName, description));
       }
     } else {
       for (String argName : argNames) {

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
@@ -119,6 +119,10 @@ public class BeanCommand extends Command {
     session.setBean(beanName);
     log.debug("selected bean: {}", beanName);
     session.getOutput().printMessage("bean is set to " + beanName);
+    int colonIdx = beanName.indexOf(':');
+    if (colonIdx > 0) {
+      session.setDomain(beanName.substring(0, colonIdx));
+    }
   }
 
   @Parameters(paramLabel = "bean", description = "MBean name with or without domain", arity = "0..1")

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainCommand.java
@@ -65,6 +65,15 @@ public class DomainCommand extends Command {
       session.unsetDomain();
       session.getOutput().printMessage("domain is unset");
     } else {
+      String currentBean = session.getBean();
+      if (currentBean != null) {
+        int colonIdx = currentBean.indexOf(':');
+        String beanDomain = colonIdx > 0 ? currentBean.substring(0, colonIdx) : null;
+        if (!domainName.equals(beanDomain)) {
+          session.setBean(null);
+          session.getOutput().printMessage("bean was unset (not part of domain " + domainName + ")");
+        }
+      }
       session.setDomain(domainName);
       log.debug("selected domain: {}", domainName);
       session.getOutput().printMessage("domain is set to " + session.getDomain());

--- a/src/main/java/sh/jmx/jmxsh/io/JlineCommandInput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/JlineCommandInput.java
@@ -2,17 +2,19 @@ package sh.jmx.jmxsh.io;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.jline.reader.impl.LineReaderImpl;
 
 public class JlineCommandInput implements CommandInput {
   private final LineReaderImpl console;
 
-  private final String prompt;
+  private final Supplier<String> promptSupplier;
 
-  public JlineCommandInput(LineReaderImpl console, String prompt) {
+  public JlineCommandInput(LineReaderImpl console, Supplier<String> promptSupplier) {
     Objects.requireNonNull(console, "Jline console reader can't be NULL");
+    Objects.requireNonNull(promptSupplier, "Prompt supplier can't be NULL");
     this.console = console;
-    this.prompt = prompt == null ? "" : prompt.trim();
+    this.promptSupplier = promptSupplier;
   }
 
   public final LineReaderImpl getConsole() {
@@ -21,7 +23,7 @@ public class JlineCommandInput implements CommandInput {
 
   @Override
   public String readLine() throws IOException {
-    return console.readLine(prompt);
+    return console.readLine(promptSupplier.get());
   }
 
   @Override
@@ -29,3 +31,4 @@ public class JlineCommandInput implements CommandInput {
     return console.readLine(prompt, '*');
   }
 }
+

--- a/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
@@ -31,7 +31,7 @@ public class PrintStreamCommandOutput implements CommandOutput {
   @Override
   public void printError(Throwable e) {
     String message = e.getMessage() != null ? e.getMessage() : e.toString();
-    messageOutput.println("#" + message);
+    messageOutput.println(message);
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
@@ -42,7 +42,7 @@ public class VerboseCommandOutput implements CommandOutput {
   @Override
   public void printMessage(String message) {
     if (modeSupplier.get() != OutputMode.SILENT) {
-      output.printMessage("#" + message);
+      output.printMessage(message);
     }
   }
 }

--- a/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
@@ -35,7 +35,8 @@ public class VerboseCommandOutput implements CommandOutput {
   public void printError(Throwable e) {
     log.error("command execution error: {}", e.getMessage(), e);
     if (modeSupplier.get() != OutputMode.SILENT) {
-      output.printMessage("#" + e.getMessage());
+      String message = e.getMessage() != null ? e.getMessage() : e.toString();
+      output.printMessage(message);
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
@@ -34,7 +34,8 @@ public class WriterCommandOutput implements CommandOutput {
   @Override
   public void printError(Throwable e) {
     try {
-      messageOutput.write("#" + e.getMessage());
+      String message = e.getMessage() != null ? e.getMessage() : e.toString();
+      messageOutput.write(message);
     } catch (IOException ex) {
       throw new RuntimeIOException("Can't print error message", ex);
     }

--- a/src/main/java/sh/jmx/jmxsh/utils/AppConfig.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/AppConfig.java
@@ -18,11 +18,18 @@ public final class AppConfig {
   private static final String KEY_LOGGING_FILE_ENABLED = "logging.file.enabled";
   private static final boolean DEFAULT_LOGGING_FILE_ENABLED = false;
 
+  private static final String KEY_PROMPT = "prompt";
+  static final String DEFAULT_PROMPT = "> ";
+
   @Getter
   private final boolean loggingFileEnabled;
 
-  private AppConfig(boolean loggingFileEnabled) {
+  @Getter
+  private final String prompt;
+
+  private AppConfig(boolean loggingFileEnabled, String prompt) {
     this.loggingFileEnabled = loggingFileEnabled;
+    this.prompt = prompt;
   }
 
   /**
@@ -45,7 +52,8 @@ public final class AppConfig {
     }
     boolean loggingFileEnabled =
         parseBoolean(props.getProperty(KEY_LOGGING_FILE_ENABLED), DEFAULT_LOGGING_FILE_ENABLED);
-    return new AppConfig(loggingFileEnabled);
+    String prompt = parseString(props.getProperty(KEY_PROMPT), DEFAULT_PROMPT);
+    return new AppConfig(loggingFileEnabled, prompt);
   }
 
   private static boolean parseBoolean(String value, boolean defaultValue) {
@@ -62,6 +70,10 @@ public final class AppConfig {
     return defaultValue;
   }
 
+  private static String parseString(String value, String defaultValue) {
+    return (value == null) ? defaultValue : value;
+  }
+
   private static final String DEFAULT_CONFIG_CONTENT =
       """
       # jmxsh configuration file
@@ -70,6 +82,14 @@ public final class AppConfig {
       # Log files are stored in $XDG_STATE_HOME/jmxsh/logs/
       # (default: ~/.local/state/jmxsh/logs/)
       # logging.file.enabled=false
+      #
+      # REPL prompt. Supports the following variables:
+      #   {server}  - connected JMX server (host:port), empty when not connected
+      #   {domain}  - currently selected domain, empty when none
+      #   {bean}    - currently selected bean, empty when none
+      # prompt=> 
+      # prompt=[{server}]> 
+      # prompt=[{domain}/{bean}]> 
       """;
 
   /**

--- a/src/main/java/sh/jmx/jmxsh/utils/AppConfig.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/AppConfig.java
@@ -87,9 +87,11 @@ public final class AppConfig {
       #   {server}  - connected JMX server (host:port), empty when not connected
       #   {domain}  - currently selected domain, empty when none
       #   {bean}    - currently selected bean, empty when none
+      #
+      # Wrap sections in {?...} to hide them when all variables inside are empty:
+      #   {?[{server}] }> 
+      #   {?[{server}] }{?{domain}}{?/{bean}}> 
       # prompt=> 
-      # prompt=[{server}]> 
-      # prompt=[{domain}/{bean}]> 
       """;
 
   /**

--- a/src/main/java/sh/jmx/jmxsh/utils/PromptTemplate.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/PromptTemplate.java
@@ -14,14 +14,23 @@ import sh.jmx.jmxsh.Session;
  *   <li>{@code {domain}} — currently selected domain; empty when none is selected
  *   <li>{@code {bean}} — currently selected bean; empty when none is selected
  * </ul>
+ *
+ * <p>Optional blocks: wrap any content in {@code {?...}} to render it only when at least one
+ * variable inside resolves to a non-empty value. Blocks may be nested.
+ * <pre>
+ *   {?[{server}] }{?{domain}}{?/{bean}}> 
+ * </pre>
+ * renders as {@code > } when nothing is selected, and as
+ * {@code [h:9010] java.lang/type=Memory> } when fully connected.
  */
 public final class PromptTemplate {
 
   private PromptTemplate() {}
 
   /**
-   * Resolves all template variables in {@code template} using the current state of {@code session}.
-   * Returns {@code template} unchanged when {@code session} is {@code null}.
+   * Resolves all template variables and optional blocks in {@code template} using the current
+   * state of {@code session}. Returns {@code template} unchanged when {@code session} is
+   * {@code null}.
    */
   public static String resolve(String template, Session session) {
     if (session == null) {
@@ -30,10 +39,82 @@ public final class PromptTemplate {
     String server = resolveServer(session);
     String domain = session.getDomain() != null ? session.getDomain() : "";
     String bean = session.getBean() != null ? session.getBean() : "";
-    return template
-        .replace("{server}", server)
-        .replace("{domain}", domain)
-        .replace("{bean}", bean);
+    return processTemplate(template, server, domain, bean);
+  }
+
+  private static String processTemplate(String template, String server, String domain, String bean) {
+    StringBuilder result = new StringBuilder();
+    int i = 0;
+    while (i < template.length()) {
+      char c = template.charAt(i);
+      if (c == '{' && i + 1 < template.length()) {
+        char next = template.charAt(i + 1);
+        if (next == '?') {
+          int blockEnd = findBlockEnd(template, i + 2);
+          if (blockEnd >= 0) {
+            String blockContent = template.substring(i + 2, blockEnd);
+            if (hasAnyNonEmptyVar(blockContent, server, domain, bean)) {
+              result.append(substituteVars(blockContent, server, domain, bean));
+            }
+            i = blockEnd + 1;
+            continue;
+          }
+        } else {
+          int end = template.indexOf('}', i + 1);
+          if (end >= 0) {
+            String varName = template.substring(i + 1, end);
+            switch (varName) {
+              case "server" -> result.append(server);
+              case "domain" -> result.append(domain);
+              case "bean"   -> result.append(bean);
+              default -> {
+                result.append('{');
+                result.append(varName);
+                result.append('}');
+              }
+            }
+            i = end + 1;
+            continue;
+          }
+        }
+      }
+      result.append(c);
+      i++;
+    }
+    return result.toString();
+  }
+
+  /**
+   * Finds the index of the closing {@code }} that balances the opening {@code {?} already
+   * consumed. Searches from {@code start}, tracking brace depth.
+   *
+   * @return index of the matching {@code }}, or {@code -1} if not found
+   */
+  static int findBlockEnd(String template, int start) {
+    int depth = 1;
+    for (int i = start; i < template.length(); i++) {
+      char c = template.charAt(i);
+      if (c == '{') {
+        depth++;
+      } else if (c == '}') {
+        depth--;
+        if (depth == 0) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  private static boolean hasAnyNonEmptyVar(String content, String server, String domain, String bean) {
+    if (content.contains("{server}") && !server.isEmpty()) return true;
+    if (content.contains("{domain}") && !domain.isEmpty()) return true;
+    if (content.contains("{bean}") && !bean.isEmpty()) return true;
+    return false;
+  }
+
+  private static String substituteVars(String template, String server, String domain, String bean) {
+    return processTemplate(template, server, domain, bean);
   }
 
   private static String resolveServer(Session session) {

--- a/src/main/java/sh/jmx/jmxsh/utils/PromptTemplate.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/PromptTemplate.java
@@ -1,0 +1,50 @@
+package sh.jmx.jmxsh.utils;
+
+import javax.management.remote.JMXServiceURL;
+
+import sh.jmx.jmxsh.Session;
+
+/**
+ * Resolves template variables in the REPL prompt string against current session state.
+ *
+ * <p>Supported variables:
+ * <ul>
+ *   <li>{@code {server}} — connected JMX server ({@code host:port} when the URL carries a host,
+ *       otherwise the full URL string); empty when not connected
+ *   <li>{@code {domain}} — currently selected domain; empty when none is selected
+ *   <li>{@code {bean}} — currently selected bean; empty when none is selected
+ * </ul>
+ */
+public final class PromptTemplate {
+
+  private PromptTemplate() {}
+
+  /**
+   * Resolves all template variables in {@code template} using the current state of {@code session}.
+   * Returns {@code template} unchanged when {@code session} is {@code null}.
+   */
+  public static String resolve(String template, Session session) {
+    if (session == null) {
+      return template;
+    }
+    String server = resolveServer(session);
+    String domain = session.getDomain() != null ? session.getDomain() : "";
+    String bean = session.getBean() != null ? session.getBean() : "";
+    return template
+        .replace("{server}", server)
+        .replace("{domain}", domain)
+        .replace("{bean}", bean);
+  }
+
+  private static String resolveServer(Session session) {
+    if (!session.isConnected()) {
+      return "";
+    }
+    JMXServiceURL url = session.getConnection().url();
+    String host = url.getHost();
+    if (host != null && !host.isBlank()) {
+      return host + ":" + url.getPort();
+    }
+    return url.toString();
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/cc/HelpCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/HelpCommandTest.java
@@ -72,6 +72,6 @@ class HelpCommandTest {
     command.setSession(session);
     command.execute();
     assertThat(writer.toString().trim())
-        .isEqualTo("a        - desc" + System.lineSeparator() + "b        - desc");
+        .isEqualTo("a           - desc" + System.lineSeparator() + "b           - desc");
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
@@ -157,6 +157,27 @@ class BeanCommandTest {
   }
 
   @Test
+  void settingFullyQualifiedBeanAutoSetsDomain() throws Exception {
+    command.setBean("java.lang:type=Memory");
+    command.setSession(session);
+    command.execute();
+    verify(session).setBean("java.lang:type=Memory");
+    verify(session).setDomain("java.lang");
+  }
+
+  @Test
+  void settingPartialBeanAutoSetsDomainFromResolvedName() throws Exception {
+    // Partial bean "type=x" is resolved to "something:type=x" using the session domain
+    command.setBean("type=x");
+    when(session.getDomain()).thenReturn("something");
+    command.setSession(session);
+    command.execute();
+    verify(session).setBean("something:type=x");
+    // domain is extracted from the resolved fully-qualified name
+    verify(session).setDomain("something");
+  }
+
+  @Test
   void suggestOptionWithUnknownOption() {
     command.setSession(session);
     assertThat(command.suggestOption("x", null)).isEmpty();

--- a/src/test/java/sh/jmx/jmxsh/cmd/DomainCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/DomainCommandTest.java
@@ -85,6 +85,29 @@ class DomainCommandTest {
     assertThat(writer.toString().trim()).isEqualTo("something");
   }
 
+  @Test
+  void settingDomainUnsetsBeanFromDifferentDomain() throws Exception {
+    when(session.getBean()).thenReturn("other.domain:type=Thing");
+    setDomainAndVerify("something", new String[] {"something"});
+    // bean belongs to "other.domain", not "something" → should be unset
+    verify(session).setBean(null);
+  }
+
+  @Test
+  void settingDomainKeepsBeanFromSameDomain() throws Exception {
+    when(session.getBean()).thenReturn("something:type=Thing");
+    setDomainAndVerify("something", new String[] {"something"});
+    // bean already belongs to "something" → should NOT be unset
+    verify(session, org.mockito.Mockito.never()).setBean(null);
+  }
+
+  @Test
+  void settingDomainWithNoBeanDoesNothing() throws Exception {
+    when(session.getBean()).thenReturn(null);
+    setDomainAndVerify("something", new String[] {"something"});
+    verify(session, org.mockito.Mockito.never()).setBean(null);
+  }
+
   /**
    * Test the case where invalid value is declined
    *

--- a/src/test/java/sh/jmx/jmxsh/e2e/CliArgumentsE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/CliArgumentsE2EIT.java
@@ -47,13 +47,7 @@ class CliArgumentsE2EIT {
           "get Name",
           "quit");
       String output = jmxsh.readAllOutput(TIMEOUT);
-      // In silent mode, informational messages prefixed with "#" should not appear
-      for (String line : output.split("\\R")) {
-        assertThat(line)
-            .as("Silent mode should not produce '#' prefixed lines, but found: " + line)
-            .doesNotStartWith("#");
-      }
-      // The attribute value should still be present
+      // In silent mode, no informational messages should appear — only data values
       assertThat(output).as("Expected 'default' value in output: " + output).contains("default");
     }
   }

--- a/src/test/java/sh/jmx/jmxsh/e2e/StartupErrorsE2EIT.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/StartupErrorsE2EIT.java
@@ -25,7 +25,7 @@ class StartupErrorsE2EIT {
       String output = jmxsh.readAllOutput(TIMEOUT);
       int exitCode = jmxsh.getExitCode();
       assertThat(exitCode).as("Invalid output file should produce non-zero exit code").isNotZero();
-      assertThat(output).as("Error should be prefixed with '#'").contains("#");
+      assertThat(output).as("Expected an error message").isNotBlank();
       assertThat(output)
           .as("Output should not contain a raw JVM stack trace: " + output)
           .doesNotContain("Exception in thread");
@@ -44,7 +44,7 @@ class StartupErrorsE2EIT {
       String output = jmxsh.readAllOutput(TIMEOUT);
       int exitCode = jmxsh.getExitCode();
       assertThat(exitCode).as("Failed auto-connect should produce non-zero exit code").isNotZero();
-      assertThat(output).as("Error should be prefixed with '#'").contains("#");
+      assertThat(output).as("Expected an error message").isNotBlank();
       assertThat(output)
           .as("Output should not contain a raw JVM stack trace: " + output)
           .doesNotContain("Exception in thread");

--- a/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
@@ -60,11 +60,11 @@ class VerboseLevelIT {
 
   @Test
   void testBriefShowsShortErrors() {
-    // Default level is BRIEF
+    // Default level is BRIEF — errors appear without stack trace
     assertThat(cc.execute("get Name")).isFalse();
     String messages = messageWriter.toString();
     assertThat(messages)
-        .as("Expected '#' prefixed error in BRIEF mode, got: " + messages).contains("#")
+        .as("Expected error message in BRIEF mode, got: " + messages).isNotBlank()
         .as("Expected no stack trace in BRIEF mode, got: " + messages).doesNotContain("\tat ");
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/VerboseLevelIT.java
@@ -35,11 +35,10 @@ class VerboseLevelIT {
 
   @Test
   void testBriefMessages() {
-    // Default level is BRIEF — messages should appear with '#' prefix
+    // Default level is BRIEF — messages should appear (without '#' prefix)
     assertThat(cc.execute("open " + jmxServer.getConnectionUrl())).isTrue();
     String messages = messageWriter.toString();
     assertThat(messages)
-        .as("Expected '#' prefixed messages in BRIEF mode, got: " + messages).contains("#")
         .as("Expected connection message, got: " + messages).contains("Connection to");
   }
 

--- a/src/test/java/sh/jmx/jmxsh/utils/AppConfigTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/AppConfigTest.java
@@ -19,6 +19,7 @@ class AppConfigTest {
   void defaultsWhenFileDoesNotExist(@TempDir Path dir) {
     AppConfig config = AppConfig.load(dir.resolve("nonexistent.properties"));
     assertThat(config.isLoggingFileEnabled()).isFalse();
+    assertThat(config.getPrompt()).isEqualTo(AppConfig.DEFAULT_PROMPT);
   }
 
   static Stream<Arguments> loggingFileEnabledCases() {
@@ -27,6 +28,23 @@ class AppConfigTest {
         Arguments.of("logging.file.enabled=false\n", false),
         Arguments.of("logging.file.enabled=yes\n", false),
         Arguments.of("some.other.key=value\n", false));
+  }
+
+  static Stream<Arguments> promptCases() {
+    return Stream.of(
+        Arguments.of("prompt=> \n", "> "),
+        Arguments.of("prompt=[{server}]> \n", "[{server}]> "),
+        Arguments.of("prompt=\n", ""),
+        Arguments.of("some.other.key=value\n", AppConfig.DEFAULT_PROMPT));
+  }
+
+  @ParameterizedTest
+  @MethodSource("promptCases")
+  void promptProperty(String content, String expected, @TempDir Path dir) throws IOException {
+    Path configFile = dir.resolve("config.properties");
+    Files.writeString(configFile, content);
+    AppConfig config = AppConfig.load(configFile);
+    assertThat(config.getPrompt()).isEqualTo(expected);
   }
 
   @ParameterizedTest

--- a/src/test/java/sh/jmx/jmxsh/utils/PromptTemplateTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/PromptTemplateTest.java
@@ -25,6 +25,50 @@ class PromptTemplateTest {
   private Connection connection;
 
   @Test
+  void optionalBlockHiddenWhenAllVarsEmpty() {
+    when(session.isConnected()).thenReturn(false);
+    assertThat(PromptTemplate.resolve("{?[{server}] }> ", session)).isEqualTo("> ");
+  }
+
+  @Test
+  void optionalBlockShownWhenVarNonEmpty() throws Exception {
+    when(session.isConnected()).thenReturn(true);
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://srv:9010"));
+    assertThat(PromptTemplate.resolve("{?[{server}] }> ", session)).isEqualTo("[srv:9010] > ");
+  }
+
+  @Test
+  void optionalBlocksComposed() throws Exception {
+    when(session.isConnected()).thenReturn(true);
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://srv:9010"));
+    when(session.getDomain()).thenReturn("java.lang");
+    when(session.getBean()).thenReturn("java.lang:type=Memory");
+    assertThat(PromptTemplate.resolve("{?[{server}] }{?{domain}}{?/{bean}}> ", session))
+        .isEqualTo("[srv:9010] java.lang/java.lang:type=Memory> ");
+  }
+
+  @Test
+  void optionalBlockPartiallyEmptyStillShown() throws Exception {
+    when(session.isConnected()).thenReturn(false);
+    when(session.getDomain()).thenReturn("java.lang");
+    when(session.getBean()).thenReturn(null);
+    // {?[{server}] } hidden (server empty), {?{domain}} shown, {?/{bean}} hidden (bean empty)
+    assertThat(PromptTemplate.resolve("{?[{server}] }{?{domain}}{?/{bean}}> ", session))
+        .isEqualTo("java.lang> ");
+  }
+
+  @Test
+  void unclosedOptionalBlockTreatedAsLiteral() {
+    when(session.isConnected()).thenReturn(false);
+    when(session.getDomain()).thenReturn(null);
+    when(session.getBean()).thenReturn(null);
+    // unclosed {? — the {? characters are emitted literally
+    assertThat(PromptTemplate.resolve("{?[{server}]> ", session)).isEqualTo("{?[]> ");
+  }
+
+  @Test
   void nullSessionReturnsTemplateUnchanged() {
     assertThat(PromptTemplate.resolve("[{server}]> ", null)).isEqualTo("[{server}]> ");
   }

--- a/src/test/java/sh/jmx/jmxsh/utils/PromptTemplateTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/PromptTemplateTest.java
@@ -1,0 +1,95 @@
+package sh.jmx.jmxsh.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.management.remote.JMXServiceURL;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import sh.jmx.jmxsh.Connection;
+import sh.jmx.jmxsh.Session;
+
+@ExtendWith(MockitoExtension.class)
+class PromptTemplateTest {
+
+  @Mock
+  private Session session;
+
+  @Mock
+  private Connection connection;
+
+  @Test
+  void nullSessionReturnsTemplateUnchanged() {
+    assertThat(PromptTemplate.resolve("[{server}]> ", null)).isEqualTo("[{server}]> ");
+  }
+
+  @Test
+  void staticPromptUnchanged() {
+    assertThat(PromptTemplate.resolve("> ", session)).isEqualTo("> ");
+  }
+
+  @Test
+  void serverVariableEmptyWhenNotConnected() {
+    when(session.isConnected()).thenReturn(false);
+    assertThat(PromptTemplate.resolve("[{server}]> ", session)).isEqualTo("[]> ");
+  }
+
+  @Test
+  void serverVariableHostPort() throws Exception {
+    when(session.isConnected()).thenReturn(true);
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://myhost:1234"));
+    assertThat(PromptTemplate.resolve("[{server}]> ", session)).isEqualTo("[myhost:1234]> ");
+  }
+
+  @Test
+  void serverVariableFallsBackToFullUrlWhenNoHost() throws Exception {
+    when(session.isConnected()).thenReturn(true);
+    when(session.getConnection()).thenReturn(connection);
+    JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:9010/jmxrmi");
+    when(connection.url()).thenReturn(url);
+    assertThat(PromptTemplate.resolve("[{server}]> ", session))
+        .isEqualTo("[" + url.toString() + "]> ");
+  }
+
+  @Test
+  void domainVariableEmptyWhenNotSet() {
+    when(session.getDomain()).thenReturn(null);
+    assertThat(PromptTemplate.resolve("{domain}> ", session)).isEqualTo("> ");
+  }
+
+  @Test
+  void domainVariableResolved() {
+    when(session.getDomain()).thenReturn("java.lang");
+    assertThat(PromptTemplate.resolve("{domain}> ", session)).isEqualTo("java.lang> ");
+  }
+
+  @Test
+  void beanVariableEmptyWhenNotSet() {
+    when(session.getBean()).thenReturn(null);
+    assertThat(PromptTemplate.resolve("{bean}> ", session)).isEqualTo("> ");
+  }
+
+  @Test
+  void beanVariableResolved() {
+    when(session.getBean()).thenReturn("type=Memory");
+    assertThat(PromptTemplate.resolve("{bean}> ", session)).isEqualTo("type=Memory> ");
+  }
+
+  @Test
+  void allVariablesResolved() throws Exception {
+    when(session.isConnected()).thenReturn(true);
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://srv:5000"));
+    when(session.getDomain()).thenReturn("java.lang");
+    when(session.getBean()).thenReturn("type=Memory");
+    assertThat(PromptTemplate.resolve("[{server} {domain}/{bean}]> ", session))
+        .isEqualTo("[srv:5000 java.lang/type=Memory]> ");
+  }
+}


### PR DESCRIPTION
## Summary

This PR delivers two related improvements: configurable REPL prompt and several UX polish fixes.

---

## 1. Configurable prompt with template variables

The default REPL prompt changes from `$> ` to `> `. Users can override it via `$XDG_CONFIG_HOME/jmxsh/config.properties` using the `prompt` key.

### Template variables

| Variable | Value |
|---|---|
| `{server}` | Connected JMX server (`host:port` when the URL carries a host, otherwise full URL string); empty when not connected |
| `{domain}` | Currently selected domain; empty when none |
| `{bean}` | Currently selected bean; empty when none |

### Optional blocks

Wrap content in `{?...}` to hide that section when all variables inside it are empty:

```properties
# Show server only when connected
prompt={?[{server}] }> 

# Show full context, cleanly hidden when nothing is selected
prompt={?[{server}] }{?{domain}}{?/{bean}}> 
```

With `{?[{server}] }{?{domain}}{?/{bean}}> `:
- Not connected, nothing selected: `> `
- Connected to host:9010, domain java.lang, bean type=Memory: `[host:9010] java.lang/java.lang:type=Memory> `

---

## 2. UX polish

**Remove `#` prefix from normal messages** — `VerboseCommandOutput.printMessage()` no longer prepends `#`. Errors (`printError`) keep their `#` prefix since they go to stderr.

**Ctrl+C exits cleanly** — `UserInterruptException` from JLine is caught in the REPL loop; prints `Interrupted.` and exits cleanly instead of printing the exception class name.

**Auto-set domain from bean** — When `BeanCommand` sets a fully-qualified bean (e.g. `java.lang:type=Memory`), it also sets the session domain to `java.lang` automatically.

**Unset bean when domain changes** — When `DomainCommand` changes the domain, if the current bean doesn't belong to the new domain, the bean is automatically unset with a message.

**Help column width** — `help` command widened to 11-char columns to fit `unsubscribe`; header capitalised.

---

## Changes

- **`VerboseCommandOutput`** — remove `#` from `printMessage()`
- **`HelpCommand`** — capitalize header; widen format column to 11
- **`CliMain`** — catch `UserInterruptException` in REPL loop
- **`AppConfig`** — add `prompt` key (default `"> "`), update config file template with optional-block examples
- **`PromptTemplate`** (new) — resolves `{server}`, `{domain}`, `{bean}`; adds `{?...}` optional block support via brace-balanced parser
- **`JlineCommandInput`** — accept `Supplier<String>` prompt for dynamic re-evaluation
- **`CommandCenter`** — expose `getSession()` for wiring in `CliMain`
- **`BeanCommand`** — auto-set domain from resolved bean name
- **`DomainCommand`** — unset bean when domain changes

## Tests

- `AppConfigTest` — `prompt` property cases
- `PromptTemplateTest` (new) — 15 cases covering variables, optional blocks, edge cases
- `BeanCommandTest` — domain auto-set from fully-qualified and partial bean names
- `DomainCommandTest` — bean unset / keep / no-op cases for domain changes
- `VerboseLevelIT` — updated to reflect no `#` on messages
- `HelpCommandTest` — updated expected column width
