### PR TITLE
perf(cmd): reduce remote JMX round trips in get, watch and bean commands

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.management.InstanceNotFoundException;
 import javax.management.JMException;
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
@@ -41,10 +40,11 @@ public class BeanCommand extends Command {
     if (bean.contains(":")) {
       try {
         ObjectName name = new ObjectName(bean);
-        con.getMBeanInfo(name);
-        return bean;
-      } catch (MalformedObjectNameException | InstanceNotFoundException _) {
-        // Invalid or unknown bean name — fall through to domain-qualified lookup
+        if (con.isRegistered(name)) {
+          return bean;
+        }
+      } catch (MalformedObjectNameException _) {
+        // Invalid bean name — fall through to domain-qualified lookup
       }
     }
 
@@ -55,10 +55,11 @@ public class BeanCommand extends Command {
     }
     try {
       ObjectName name = new ObjectName(domainName + ":" + bean);
-      con.getMBeanInfo(name);
-      return domainName + ":" + bean;
-    } catch (MalformedObjectNameException | InstanceNotFoundException _) {
-      // Invalid or unknown bean name — fall through to throw IllegalArgumentException
+      if (con.isRegistered(name)) {
+        return domainName + ":" + bean;
+      }
+    } catch (MalformedObjectNameException _) {
+      // Invalid bean name — fall through to throw IllegalArgumentException
     }
     throw new IllegalArgumentException("Bean name " + bean + " isn't valid");
   }
@@ -113,9 +114,6 @@ public class BeanCommand extends Command {
       session.getOutput().printMessage("bean is unset");
       return;
     }
-    ObjectName name = new ObjectName(beanName);
-    MBeanServerConnection con = session.getConnection().getServerConnection();
-    con.getMBeanInfo(name);
     session.setBean(beanName);
     log.debug("selected bean: {}", beanName);
     session.getOutput().printMessage("bean is set to " + beanName);

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -3,11 +3,15 @@ package sh.jmx.jmxsh.cmd;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
+import javax.management.Attribute;
 import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServerConnection;
@@ -75,6 +79,7 @@ public class GetCommand extends DomainBeanAwareCommand {
       }
     }
     ValueOutputFormat format = new ValueOutputFormat(2, showDescription, showQuotationMarks);
+    Map<String, Object> fetchedValues = fetchValues(con, name, attributeNames);
     for (Map.Entry<String, MBeanAttributeInfo> entry : attributeNames.entrySet()) {
       String attributeName = entry.getKey();
       MBeanAttributeInfo i = entry.getValue();
@@ -88,11 +93,15 @@ public class GetCommand extends DomainBeanAwareCommand {
 
         Object result = null;
 
-        try {
-          result = con.getAttribute(name, attributeNameToRequest);
-        } catch (RuntimeMBeanException e) {
-          session.getOutput().printMessage(
-              "Could not get attribute " + attributeNameToRequest + ": " + e.getMessage());
+        if (fetchedValues.containsKey(attributeNameToRequest)) {
+          result = fetchedValues.get(attributeNameToRequest);
+        } else {
+          try {
+            result = con.getAttribute(name, attributeNameToRequest);
+          } catch (RuntimeMBeanException e) {
+            session.getOutput().printMessage(
+                "Could not get attribute " + attributeNameToRequest + ": " + e.getMessage());
+          }
         }
 
         if (result instanceof CompositeDataSupport support && attributeNameElements.length > 1) {
@@ -116,6 +125,30 @@ public class GetCommand extends DomainBeanAwareCommand {
         session.getOutput().printMessage(i.getName() + " is not readable");
       }
     }
+  }
+
+  /**
+   * Fetches all readable attributes in a single bulk {@code getAttributes} round trip. Attributes
+   * that the server failed to read are absent from the result; callers fall back to individual
+   * {@code getAttribute} calls for those to surface the error.
+   */
+  private static Map<String, Object> fetchValues(
+      MBeanServerConnection con, ObjectName name, Map<String, MBeanAttributeInfo> attributeNames)
+      throws IOException, JMException {
+    Set<String> namesToFetch = new LinkedHashSet<>();
+    for (Map.Entry<String, MBeanAttributeInfo> entry : attributeNames.entrySet()) {
+      if (entry.getValue().isReadable()) {
+        namesToFetch.add(entry.getKey().split("\\.")[0]);
+      }
+    }
+    Map<String, Object> values = new HashMap<>();
+    if (!namesToFetch.isEmpty()) {
+      for (Attribute attribute :
+          con.getAttributes(name, namesToFetch.toArray(String[]::new)).asList()) {
+        values.put(attribute.getName(), attribute.getValue());
+      }
+    }
+    return values;
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -58,72 +58,81 @@ public class GetCommand extends DomainBeanAwareCommand {
     session.getOutput().printMessage("mbean = " + beanName + ":");
     MBeanServerConnection con = session.getConnection().getServerConnection();
     MBeanAttributeInfo[] ais = con.getMBeanInfo(name).getAttributes();
-    Map<String, MBeanAttributeInfo> attributeNames =
-        new LinkedHashMap<>();
+    Map<String, MBeanAttributeInfo> attributeNames = resolveAttributeNames(ais);
+    ValueOutputFormat format = new ValueOutputFormat(2, showDescription, showQuotationMarks);
+    Map<String, Object> fetchedValues = fetchValues(con, name, attributeNames);
+    for (Map.Entry<String, MBeanAttributeInfo> entry : attributeNames.entrySet()) {
+      MBeanAttributeInfo i = entry.getValue();
+      if (i.isReadable()) {
+        displayAttribute(con, name, beanName, entry.getKey(), i, fetchedValues, format);
+      } else {
+        session.getOutput().printMessage(i.getName() + " is not readable");
+      }
+    }
+  }
+
+  private Map<String, MBeanAttributeInfo> resolveAttributeNames(MBeanAttributeInfo[] ais) {
+    Map<String, MBeanAttributeInfo> attributeNames = new LinkedHashMap<>();
     if (attributes.contains("*")) {
       for (MBeanAttributeInfo ai : ais) {
         attributeNames.put(ai.getName(), ai);
       }
-    } else {
-      for (String arg : attributes) {
-        String[] attributeNameElements = arg.split("\\.");
-
-        String firstPath = attributeNameElements[0];
-
-        for (MBeanAttributeInfo ai : ais) {
-          if (ai.getName().equals(firstPath)) {
-            attributeNames.put(arg, ai);
-            break;
-          }
+      return attributeNames;
+    }
+    for (String arg : attributes) {
+      String firstPath = arg.split("\\.")[0];
+      for (MBeanAttributeInfo ai : ais) {
+        if (ai.getName().equals(firstPath)) {
+          attributeNames.put(arg, ai);
+          break;
         }
       }
     }
-    ValueOutputFormat format = new ValueOutputFormat(2, showDescription, showQuotationMarks);
-    Map<String, Object> fetchedValues = fetchValues(con, name, attributeNames);
-    for (Map.Entry<String, MBeanAttributeInfo> entry : attributeNames.entrySet()) {
-      String attributeName = entry.getKey();
-      MBeanAttributeInfo i = entry.getValue();
-      if (i.isReadable()) {
-        String[] attributeNameElements = attributeName.split("\\.");
+    return attributeNames;
+  }
 
-        String attributeNameToRequest = attributeName;
-        if (attributeNameElements.length > 1) {
-          attributeNameToRequest = attributeNameElements[0];
-        }
+  private void displayAttribute(
+      MBeanServerConnection con,
+      ObjectName name,
+      String beanName,
+      String attributeName,
+      MBeanAttributeInfo info,
+      Map<String, Object> fetchedValues,
+      ValueOutputFormat format)
+      throws IOException, JMException {
+    Session session = getSession();
+    String[] attributeNameElements = attributeName.split("\\.");
+    String attributeNameToRequest = attributeNameElements[0];
 
-        Object result = null;
+    Object result = null;
 
-        if (fetchedValues.containsKey(attributeNameToRequest)) {
-          result = fetchedValues.get(attributeNameToRequest);
-        } else {
-          try {
-            result = con.getAttribute(name, attributeNameToRequest);
-          } catch (RuntimeMBeanException e) {
-            session.getOutput().printMessage(
-                "Could not get attribute " + attributeNameToRequest + ": " + e.getMessage());
-          }
-        }
-
-        if (result instanceof CompositeDataSupport support && attributeNameElements.length > 1) {
-            result = support.get(attributeNameElements[1]);
-        }
-
-        if (simpleFormat) {
-          format.printValue(session.getOutput(), result);
-        } else if (completeLine) {
-          format.printValue(
-              session.getOutput(),
-              "mbean = %s # %s = %s".formatted(beanName, attributeName, result));
-        } else {
-          format.printExpression(session.getOutput(), attributeName, result, i.getDescription());
-        }
-        session.getOutput().print(delimiter);
-        if (!singleLine) {
-          session.getOutput().println("");
-        }
-      } else {
-        session.getOutput().printMessage(i.getName() + " is not readable");
+    if (fetchedValues.containsKey(attributeNameToRequest)) {
+      result = fetchedValues.get(attributeNameToRequest);
+    } else {
+      try {
+        result = con.getAttribute(name, attributeNameToRequest);
+      } catch (RuntimeMBeanException e) {
+        session.getOutput().printMessage(
+            "Could not get attribute " + attributeNameToRequest + ": " + e.getMessage());
       }
+    }
+
+    if (result instanceof CompositeDataSupport support && attributeNameElements.length > 1) {
+      result = support.get(attributeNameElements[1]);
+    }
+
+    if (simpleFormat) {
+      format.printValue(session.getOutput(), result);
+    } else if (completeLine) {
+      format.printValue(
+          session.getOutput(),
+          "mbean = %s # %s = %s".formatted(beanName, attributeName, result));
+    } else {
+      format.printExpression(session.getOutput(), attributeName, result, info.getDescription());
+    }
+    session.getOutput().print(delimiter);
+    if (!singleLine) {
+      session.getOutput().println("");
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -127,11 +127,6 @@ public class GetCommand extends DomainBeanAwareCommand {
     }
   }
 
-  /**
-   * Fetches all readable attributes in a single bulk {@code getAttributes} round trip. Attributes
-   * that the server failed to read are absent from the result; callers fall back to individual
-   * {@code getAttribute} calls for those to surface the error.
-   */
   private static Map<String, Object> fetchValues(
       MBeanServerConnection con, ObjectName name, Map<String, MBeanAttributeInfo> attributeNames)
       throws IOException, JMException {

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -4,12 +4,15 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import javax.management.Attribute;
 import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServerConnection;
@@ -134,11 +137,17 @@ public class WatchCommand extends Command {
   }
 
   private Object getAttributeValue(
-      ObjectName beanName, String attributeName, MBeanServerConnection connection)
+      ObjectName beanName,
+      String attributeName,
+      MBeanServerConnection connection,
+      Map<String, Object> fetchedValues)
       throws IOException {
     // %now is a reserved keyword for current instant
     if (BUILDING_ATTRIBUTE_NOW.equals(attributeName)) {
       return Instant.now();
+    }
+    if (fetchedValues.containsKey(attributeName)) {
+      return fetchedValues.get(attributeName);
     }
     try {
       return connection.getAttribute(beanName, attributeName);
@@ -147,8 +156,34 @@ public class WatchCommand extends Command {
     }
   }
 
+  /**
+   * Fetches all watched attributes in a single bulk {@code getAttributes} round trip. Attributes
+   * the server failed to read are absent from the result; {@code getAttributeValue} falls back to
+   * individual calls for those to preserve per-attribute error reporting.
+   */
+  private Map<String, Object> fetchValues(ObjectName beanName, MBeanServerConnection connection)
+      throws IOException {
+    List<String> namesToFetch = attributes.stream()
+        .filter(a -> !BUILDING_ATTRIBUTE_NOW.equals(a))
+        .distinct()
+        .toList();
+    Map<String, Object> values = new HashMap<>();
+    if (!namesToFetch.isEmpty()) {
+      try {
+        for (Attribute attribute :
+            connection.getAttributes(beanName, namesToFetch.toArray(String[]::new)).asList()) {
+          values.put(attribute.getName(), attribute.getValue());
+        }
+      } catch (JMException e) {
+        log.debug("bulk attribute fetch failed, falling back to individual calls", e);
+      }
+    }
+    return values;
+  }
+
   private void printValues(ObjectName beanName, MBeanServerConnection connection, LineOutput output)
       throws IOException {
+    Map<String, Object> fetchedValues = fetchValues(beanName, connection);
     String result;
     if (outputFormat == null) {
       var sb = new StringBuilder();
@@ -159,14 +194,14 @@ public class WatchCommand extends Command {
         } else {
           sb.append(", ");
         }
-        sb.append(getAttributeValue(beanName, attributeName, connection));
+        sb.append(getAttributeValue(beanName, attributeName, connection, fetchedValues));
       }
       result = sb.toString();
     } else {
       Object[] values = new Object[attributes.size()];
       int i = 0;
       for (String attributeNamne : attributes) {
-        values[i++] = getAttributeValue(beanName, attributeNamne, connection);
+        values[i++] = getAttributeValue(beanName, attributeNamne, connection, fetchedValues);
       }
       result = outputFormat.formatted(values);
     }

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -156,11 +156,6 @@ public class WatchCommand extends Command {
     }
   }
 
-  /**
-   * Fetches all watched attributes in a single bulk {@code getAttributes} round trip. Attributes
-   * the server failed to read are absent from the result; {@code getAttributeValue} falls back to
-   * individual calls for those to preserve per-attribute error reporting.
-   */
   private Map<String, Object> fetchValues(ObjectName beanName, MBeanServerConnection connection)
       throws IOException {
     List<String> namesToFetch = attributes.stream()

--- a/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/BeanCommandTest.java
@@ -49,10 +49,11 @@ class BeanCommandTest {
     if (domainName != null) {
       when(session.getDomain()).thenReturn(domainName);
     }
+    when(con.isRegistered(new ObjectName(expectedBean))).thenReturn(true);
     command.setSession(session);
     command.execute();
     verify(session).setBean(expectedBean);
-    verify(con, atLeastOnce()).getMBeanInfo(new ObjectName(expectedBean));
+    verify(con, atLeastOnce()).isRegistered(new ObjectName(expectedBean));
   }
 
   /**
@@ -159,6 +160,7 @@ class BeanCommandTest {
   @Test
   void settingFullyQualifiedBeanAutoSetsDomain() throws Exception {
     command.setBean("java.lang:type=Memory");
+    when(con.isRegistered(new ObjectName("java.lang:type=Memory"))).thenReturn(true);
     command.setSession(session);
     command.execute();
     verify(session).setBean("java.lang:type=Memory");
@@ -170,6 +172,7 @@ class BeanCommandTest {
     // Partial bean "type=x" is resolved to "something:type=x" using the session domain
     command.setBean("type=x");
     when(session.getDomain()).thenReturn("something");
+    when(con.isRegistered(new ObjectName("something:type=x"))).thenReturn(true);
     command.setSession(session);
     command.execute();
     verify(session).setBean("something:type=x");
@@ -188,8 +191,7 @@ class BeanCommandTest {
     command.setBean("some:type=Thing");
     when(session.getConnection()).thenReturn(connection);
     when(connection.getServerConnection()).thenReturn(con);
-    when(con.getMBeanInfo(new ObjectName("some:type=Thing")))
-        .thenThrow(new javax.management.InstanceNotFoundException("not found"));
+    when(con.isRegistered(new ObjectName("some:type=Thing"))).thenReturn(false);
     // domain is null → triggers IAE about specifying domain
     command.setSession(session);
     assertThatThrownBy(command::execute).isInstanceOf(IllegalArgumentException.class)
@@ -202,8 +204,7 @@ class BeanCommandTest {
     when(session.getDomain()).thenReturn("mydomain");
     when(session.getConnection()).thenReturn(connection);
     when(connection.getServerConnection()).thenReturn(con);
-    when(con.getMBeanInfo(new ObjectName("mydomain:type=Thing")))
-        .thenThrow(new javax.management.InstanceNotFoundException("not found"));
+    when(con.isRegistered(new ObjectName("mydomain:type=Thing"))).thenReturn(false);
     command.setSession(session);
     assertThatThrownBy(command::execute).isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("isn't valid");

--- a/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
@@ -193,8 +193,7 @@ class GetCommandTest {
     org.mockito.Mockito.verify(con).getAttributes(name, new String[] {"x", "y"});
     org.mockito.Mockito.verify(con, org.mockito.Mockito.never())
         .getAttribute(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
-    assertThat(writer.toString())
-        .isEqualTo("1" + System.lineSeparator() + "2" + System.lineSeparator());
+    assertThat(writer).hasToString("1" + System.lineSeparator() + "2" + System.lineSeparator());
   }
 
   @Test
@@ -222,7 +221,7 @@ class GetCommandTest {
     command.execute();
 
     assertThat(messageWriter.toString()).contains("Could not get attribute x");
-    assertThat(writer.toString()).isEqualTo("null" + System.lineSeparator());
+    assertThat(writer).hasToString("null" + System.lineSeparator());
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
@@ -12,11 +12,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
+import javax.management.Attribute;
+import javax.management.AttributeList;
 import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
 import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenDataException;
@@ -83,12 +86,13 @@ class GetCommandTest {
     try {
       when(con.getDomains())
           .thenReturn(new String[] {domain, randomAlphabetic(5)});
+      when(con.isRegistered(new ObjectName(expectedBean))).thenReturn(true);
       when(con.getMBeanInfo(new ObjectName(expectedBean))).thenReturn(beanInfo);
       when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[] {attributeInfo});
       when(attributeInfo.getName()).thenReturn(attributePath[0]);
       when(attributeInfo.isReadable()).thenReturn(true);
-      when(con.getAttribute(new ObjectName(expectedBean), attributePath[0]))
-          .thenReturn(expectedValue);
+      when(con.getAttributes(new ObjectName(expectedBean), new String[] {attributePath[0]}))
+          .thenReturn(new AttributeList(List.of(new Attribute(attributePath[0], expectedValue))));
 
       command.setSession(session);
       command.execute();
@@ -159,6 +163,66 @@ class GetCommandTest {
   @Test
   void executeForSingleLineOutput() {
     getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "");
+  }
+
+  @Test
+  void fetchesMultipleAttributesInSingleBulkCall() throws Exception {
+    ObjectName name = new ObjectName("a:type=x");
+    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
+    MBeanAttributeInfo attr1 = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    MBeanAttributeInfo attr2 = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    when(con.getDomains()).thenReturn(new String[] {"a"});
+    when(con.isRegistered(name)).thenReturn(true);
+    when(con.getMBeanInfo(name)).thenReturn(beanInfo);
+    when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[] {attr1, attr2});
+    when(attr1.getName()).thenReturn("x");
+    when(attr1.isReadable()).thenReturn(true);
+    when(attr2.getName()).thenReturn("y");
+    when(attr2.isReadable()).thenReturn(true);
+    when(con.getAttributes(name, new String[] {"x", "y"}))
+        .thenReturn(new AttributeList(
+            List.of(new Attribute("x", "1"), new Attribute("y", "2"))));
+
+    command.setDomain("a");
+    command.setBean("type=x");
+    command.setAttributes(List.of("x", "y"));
+    command.setSimpleFormat(true);
+    command.setSession(session);
+    command.execute();
+
+    org.mockito.Mockito.verify(con).getAttributes(name, new String[] {"x", "y"});
+    org.mockito.Mockito.verify(con, org.mockito.Mockito.never())
+        .getAttribute(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    assertThat(writer.toString())
+        .isEqualTo("1" + System.lineSeparator() + "2" + System.lineSeparator());
+  }
+
+  @Test
+  void fallsBackToSingleGetWhenAttributeMissingFromBulkResult() throws Exception {
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, messageWriter));
+    ObjectName name = new ObjectName("a:type=x");
+    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
+    MBeanAttributeInfo attributeInfo = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    when(con.getDomains()).thenReturn(new String[] {"a"});
+    when(con.isRegistered(name)).thenReturn(true);
+    when(con.getMBeanInfo(name)).thenReturn(beanInfo);
+    when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[] {attributeInfo});
+    when(attributeInfo.getName()).thenReturn("x");
+    when(attributeInfo.isReadable()).thenReturn(true);
+    when(con.getAttributes(name, new String[] {"x"})).thenReturn(new AttributeList());
+    when(con.getAttribute(name, "x"))
+        .thenThrow(new RuntimeMBeanException(new IllegalStateException("boom"), "failed"));
+
+    command.setDomain("a");
+    command.setBean("type=x");
+    command.setAttributes(List.of("x"));
+    command.setSimpleFormat(true);
+    command.setSession(session);
+    command.execute();
+
+    assertThat(messageWriter.toString()).contains("Could not get attribute x");
+    assertThat(writer.toString()).isEqualTo("null" + System.lineSeparator());
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/cmd/InfoCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/InfoCommandTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.io.StringWriter;
 
 import javax.management.MBeanAttributeInfo;

--- a/src/test/java/sh/jmx/jmxsh/cmd/InfoCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/InfoCommandTest.java
@@ -42,12 +42,13 @@ class InfoCommandTest {
 
   /** Set up objects to test */
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws Exception {
     command = new InfoCommand();
     writer = new StringWriter();
     lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
     lenient().when(session.getConnection()).thenReturn(connection);
     lenient().when(connection.getServerConnection()).thenReturn(con);
+    lenient().when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
   }
 
   /**

--- a/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
@@ -40,12 +40,13 @@ class RunCommandTest {
 
   /** Setup objects to test */
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws Exception {
     command = new RunCommand();
     writer = new StringWriter();
     lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
     lenient().when(session.getConnection()).thenReturn(connection);
     lenient().when(connection.getServerConnection()).thenReturn(con);
+    lenient().when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
   }
 
   /** @throws Exception */

--- a/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
 

--- a/src/test/java/sh/jmx/jmxsh/cmd/SetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/SetCommandTest.java
@@ -43,12 +43,13 @@ class SetCommandTest {
 
   /** Set up objects to test */
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws Exception {
     command = new SetCommand();
     writer = new StringWriter();
     lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
     lenient().when(session.getConnection()).thenReturn(connection);
     lenient().when(connection.getServerConnection()).thenReturn(con);
+    lenient().when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
   }
 
   private void setValueAndVerify(String expr, String type, Object expected) {

--- a/src/test/java/sh/jmx/jmxsh/cmd/SubscribeCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/SubscribeCommandTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.Notification;
 import javax.management.NotificationListener;
@@ -42,12 +41,13 @@ class SubscribeCommandTest {
 
   /** Setup objects to test */
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws Exception {
     command = new SubscribeCommand();
     writer = new StringWriter();
     lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
     lenient().when(session.getConnection()).thenReturn(connection);
     lenient().when(connection.getServerConnection()).thenReturn(con);
+    lenient().when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
   }
 
   @AfterEach
@@ -60,11 +60,9 @@ class SubscribeCommandTest {
   void executeOneNotification() throws Exception {
     command.setBean("a:type=x");
 
-    MBeanInfo beanInfo = mock(MBeanInfo.class);
     Notification notification = mock(Notification.class);
 
     ObjectName objectName = new ObjectName("a:type=x");
-    when(con.getMBeanInfo(objectName)).thenReturn(beanInfo);
     when(notification.getTimeStamp()).thenReturn(123L);
     when(notification.getSource()).thenReturn("xyz");
     when(notification.getType()).thenReturn("azerty");
@@ -97,11 +95,9 @@ class SubscribeCommandTest {
   void executeTwoNotifications() throws Exception {
     command.setBean("a:type=x");
 
-    MBeanInfo beanInfo = mock(MBeanInfo.class);
     Notification notification = mock(Notification.class);
 
     ObjectName objectName = new ObjectName("a:type=x");
-    when(con.getMBeanInfo(objectName)).thenReturn(beanInfo);
     when(notification.getTimeStamp()).thenReturn(123L);
     when(notification.getSource()).thenReturn("xyz");
     when(notification.getType()).thenReturn("azerty");

--- a/src/test/java/sh/jmx/jmxsh/cmd/SubscribeCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/SubscribeCommandTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.io.StringWriter;
 
 import javax.management.MBeanServerConnection;

--- a/src/test/java/sh/jmx/jmxsh/cmd/UnsubscribeCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/UnsubscribeCommandTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.Notification;
 import javax.management.NotificationListener;
@@ -44,13 +43,14 @@ class UnsubscribeCommandTest {
 
   /** Setup objects to test */
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws Exception {
     subscribeCommand = new SubscribeCommand();
     unsubscribeCommand = new UnsubscribeCommand();
     writer = new StringWriter();
     lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
     lenient().when(session.getConnection()).thenReturn(connection);
     lenient().when(connection.getServerConnection()).thenReturn(con);
+    lenient().when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
   }
 
   @AfterEach
@@ -64,10 +64,7 @@ class UnsubscribeCommandTest {
     subscribeCommand.setBean("a:type=x");
     unsubscribeCommand.setBean("a:type=x");
 
-    MBeanInfo beanInfo = mock(MBeanInfo.class);
     ObjectName objectName = new ObjectName("a:type=x");
-
-    when(con.getMBeanInfo(objectName)).thenReturn(beanInfo);
 
     subscribeCommand.setSession(session);
     subscribeCommand.execute();
@@ -77,7 +74,7 @@ class UnsubscribeCommandTest {
     unsubscribeCommand.execute();
     assertThat(SubscribeCommand.getListeners()).isEmpty();
 
-    verify(con, atLeast(2)).getMBeanInfo(objectName);
+    verify(con, atLeast(2)).isRegistered(objectName);
     verify(con)
         .addNotificationListener(
             eq(objectName),
@@ -93,11 +90,9 @@ class UnsubscribeCommandTest {
   void executeTwoNotifications() throws Exception {
     subscribeCommand.setBean("a:type=x");
 
-    MBeanInfo beanInfo = mock(MBeanInfo.class);
     Notification notification = mock(Notification.class);
 
     ObjectName objectName = new ObjectName("a:type=x");
-    when(con.getMBeanInfo(objectName)).thenReturn(beanInfo);
     when(notification.getTimeStamp()).thenReturn(123L);
     when(notification.getSource()).thenReturn("xyz");
     when(notification.getType()).thenReturn("azerty");

--- a/src/test/java/sh/jmx/jmxsh/cmd/UnsubscribeCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/UnsubscribeCommandTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.io.StringWriter;
 
 import javax.management.MBeanServerConnection;

--- a/src/test/java/sh/jmx/jmxsh/cmd/WatchCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/WatchCommandTest.java
@@ -1,8 +1,26 @@
 package sh.jmx.jmxsh.cmd;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.StringWriter;
+import java.util.List;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+
+import sh.jmx.jmxsh.Connection;
 import sh.jmx.jmxsh.Session;
+import sh.jmx.jmxsh.io.CommandInput;
+import sh.jmx.jmxsh.io.WriterCommandOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,19 +30,178 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class WatchCommandTest {
 
+  private static final String BEAN_NAME = "a:type=x";
+
   @Mock
   private Session session;
+  @Mock
+  private Connection connection;
+  @Mock
+  private MBeanServerConnection con;
 
   private WatchCommand command;
+  private StringWriter writer;
 
   @BeforeEach
   void setUp() {
     command = new WatchCommand();
+    writer = new StringWriter();
+  }
+
+  private void mockConnectedSession() throws Exception {
+    lenient().when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
+    lenient().when(session.getDomain()).thenReturn("a");
+    lenient().when(session.getBean()).thenReturn(BEAN_NAME);
+    lenient().when(session.getConnection()).thenReturn(connection);
+    lenient().when(connection.getServerConnection()).thenReturn(con);
+  }
+
+  private void awaitOutputContains(String expected) throws InterruptedException {
+    for (int i = 0; i < 100 && !writer.toString().contains(expected); i++) {
+      Thread.sleep(50);
+    }
+    assertThat(writer.toString()).contains(expected);
+  }
+
+  @Test
+  void executeReportModeFetchesAttributesInBulk() throws Exception {
+    mockConnectedSession();
+    when(con.getAttributes(new ObjectName(BEAN_NAME), new String[] {"x", "y"}))
+        .thenReturn(new AttributeList(List.of(new Attribute("x", 1), new Attribute("y", 2))));
+
+    command.setAttributes(List.of("x", "y"));
+    command.setReport(true);
+    command.setStopAfter(1);
+    command.setRefreshInterval(5);
+    command.setSession(session);
+    command.execute();
+
+    awaitOutputContains("1, 2");
+  }
+
+  @Test
+  void executeReportModeWithOutputFormat() throws Exception {
+    mockConnectedSession();
+    when(con.getAttributes(new ObjectName(BEAN_NAME), new String[] {"x", "y"}))
+        .thenReturn(new AttributeList(List.of(new Attribute("x", 1), new Attribute("y", 2))));
+
+    command.setAttributes(List.of("x", "y"));
+    command.setOutputFormat("%s|%s");
+    command.setReport(true);
+    command.setStopAfter(1);
+    command.setRefreshInterval(5);
+    command.setSession(session);
+    command.execute();
+
+    awaitOutputContains("1|2");
+  }
+
+  @Test
+  void executeReportModeFallsBackWhenAttributeMissingFromBulkResult() throws Exception {
+    mockConnectedSession();
+    ObjectName name = new ObjectName(BEAN_NAME);
+    when(con.getAttributes(name, new String[] {"x"})).thenReturn(new AttributeList());
+    when(con.getAttribute(name, "x")).thenThrow(new AttributeNotFoundException("x"));
+
+    command.setAttributes(List.of("x"));
+    command.setReport(true);
+    command.setStopAfter(1);
+    command.setRefreshInterval(5);
+    command.setSession(session);
+    command.execute();
+
+    awaitOutputContains("AttributeNotFoundException");
+  }
+
+  @Test
+  void executeReportModeWithNowPseudoAttribute() throws Exception {
+    mockConnectedSession();
+
+    command.setAttributes(List.of("%now"));
+    command.setReport(true);
+    command.setStopAfter(1);
+    command.setRefreshInterval(5);
+    command.setSession(session);
+    command.execute();
+
+    awaitOutputContains("Z");
+  }
+
+  @Test
+  void executeReportWithoutStopAfterThrows() {
+    command.setReport(true);
+    command.setSession(session);
+
+    assertThatThrownBy(command::execute)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("--report");
+  }
+
+  @Test
+  void executeWithoutDomainThrows() {
+    when(session.getConnection()).thenReturn(connection);
+    command.setSession(session);
+
+    assertThatThrownBy(command::execute)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("domain");
+  }
+
+  @Test
+  void executeWithoutBeanThrows() {
+    when(session.getConnection()).thenReturn(connection);
+    when(session.getDomain()).thenReturn("a");
+    command.setSession(session);
+
+    assertThatThrownBy(command::execute)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("bean");
+  }
+
+  @Test
+  void executeWithoutConsoleInputThrows() throws Exception {
+    when(session.getConnection()).thenReturn(connection);
+    when(session.getDomain()).thenReturn("a");
+    when(session.getBean()).thenReturn(BEAN_NAME);
+    when(connection.getServerConnection()).thenReturn(con);
+    when(session.getInput()).thenReturn(mock(CommandInput.class));
+    command.setSession(session);
+
+    assertThatThrownBy(command::execute).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void suggestArgumentWithBean() throws Exception {
+    when(session.getBean()).thenReturn(BEAN_NAME);
+    when(session.getConnection()).thenReturn(connection);
+    when(connection.getServerConnection()).thenReturn(con);
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    MBeanAttributeInfo attributeInfo = mock(MBeanAttributeInfo.class);
+    when(con.getMBeanInfo(new ObjectName(BEAN_NAME))).thenReturn(beanInfo);
+    when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[] {attributeInfo});
+    when(attributeInfo.getName()).thenReturn("x");
+    command.setSession(session);
+
+    assertThat(command.suggestArgument(null)).containsExactly("x", "%now");
   }
 
   @Test
   void suggestArgumentWithNoBean() {
+    when(session.getBean()).thenReturn(null);
     command.setSession(session);
+
     assertThat(command.suggestArgument(null)).isEmpty();
+  }
+
+  @Test
+  void invalidRefreshIntervalThrows() {
+    assertThatThrownBy(() -> command.setRefreshInterval(0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void invalidStopAfterThrows() {
+    assertThatThrownBy(() -> command.setStopAfter(-1))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
## Why

When connected to a remote JMX server (RMI or JMXMP), every `MBeanServerConnection` call is a full network round trip. Commands were issuing far more calls than necessary, so latency scaled linearly with attribute count and redundant validations.

## What changed

- **`get`**: all requested attributes are now fetched with a single bulk `getAttributes(ObjectName, String[])` call instead of one `getAttribute()` round trip per attribute. Attributes the server fails to read are absent from the bulk result; only those fall back to an individual `getAttribute()` call, so the existing "Could not get attribute X" error reporting and output format are preserved.
- **`watch`**: same bulk fetch, once per refresh tick. With several attributes at the default 1s interval this cuts the steady-state call rate by the attribute count. The `%now` pseudo-attribute is still resolved locally.
- **`bean`**: bean existence is now validated with the lightweight `isRegistered()` (returns a boolean) instead of `getMBeanInfo()` (serializes the full MBeanInfo tree), and a fully redundant second `getMBeanInfo()` call in `BeanCommand.execute()` was removed. Since `get`, `set`, `run`, `info`, `subscribe` and `unsubscribe` all validate beans through `BeanCommand.getBeanName()`, they benefit too.

## Notes for review

- `getAttributes` is part of `MBeanServerConnection` since JMX 1.2, so there is no compatibility concern for RMI or JMXMP.
- The fallback path in `get`/`watch` means the error case costs one extra call per failed attribute, but the happy path is always a single round trip.
- Tests updated accordingly (`isRegistered` stubs, `AttributeList` mocks) plus two new tests covering the single-bulk-call behavior and the fallback path. `mvn verify` passes (170 unit + 63 IT/E2E tests).

Out of scope by design: tab-completion caching and connect timeouts were considered and deliberately excluded.