### PR TITLE
fix(cmd): refresh connector address after starting management agent

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/attach/JavaProcess.java
+++ b/src/main/java/sh/jmx/jmxsh/attach/JavaProcess.java
@@ -2,21 +2,23 @@ package sh.jmx.jmxsh.attach;
 
 import java.io.IOException;
 
-import lombok.AccessLevel;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 
 import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class JavaProcess {
 
   @NonNull
   private final VirtualMachineDescriptor vmd;
-  private final String address;
+  private String address;
+
+  JavaProcess(@NonNull VirtualMachineDescriptor vmd, String address) {
+    this.vmd = vmd;
+    this.address = address;
+  }
 
   public String getDisplayName() {
     return vmd.displayName();
@@ -31,10 +33,20 @@ public class JavaProcess {
   }
 
   public void startManagementAgent() throws IOException {
+    VirtualMachine vm = null;
     try {
-      VirtualMachine.attach(vmd).startLocalManagementAgent();
+      vm = VirtualMachine.attach(vmd);
+      address = vm.startLocalManagementAgent();
     } catch (SecurityException | AttachNotSupportedException e) {
       throw new IllegalStateException("Cannot start management agent on VM with pid " + vmd.id(), e);
+    } finally {
+      if (vm != null) {
+        try {
+          vm.detach();
+        } catch (IOException _) {
+          // Could not detach from the VM, ignoring as we cannot do anything about it
+        }
+      }
     }
   }
 

--- a/src/test/java/sh/jmx/jmxsh/attach/JavaProcessTest.java
+++ b/src/test/java/sh/jmx/jmxsh/attach/JavaProcessTest.java
@@ -1,0 +1,66 @@
+package sh.jmx.jmxsh.attach;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
+
+@ExtendWith(MockitoExtension.class)
+class JavaProcessTest {
+
+  @Mock
+  private VirtualMachineDescriptor vmd;
+
+  @Mock
+  private VirtualMachine vm;
+
+  @Test
+  void should_becomeManageable_when_managementAgentStarts() throws IOException {
+    // Given
+    JavaProcess unit = new JavaProcess(vmd, null);
+
+    try (MockedStatic<VirtualMachine> attachApi = mockStatic(VirtualMachine.class)) {
+      attachApi.when(() -> VirtualMachine.attach(vmd)).thenReturn(vm);
+      when(vm.startLocalManagementAgent()).thenReturn("service:jmx:rmi://127.0.0.1/stub");
+
+      // When
+      unit.startManagementAgent();
+    }
+
+    // Then
+    assertThat(unit.isManageable()).isTrue();
+    assertThat(unit.toUrl()).isEqualTo("service:jmx:rmi://127.0.0.1/stub");
+    verify(vm).detach();
+  }
+
+  @Test
+  void should_remainUnmanageable_when_attachIsNotSupported() {
+    // Given
+    JavaProcess unit = new JavaProcess(vmd, null);
+    when(vmd.id()).thenReturn("42");
+
+    try (MockedStatic<VirtualMachine> attachApi = mockStatic(VirtualMachine.class)) {
+      attachApi.when(() -> VirtualMachine.attach(vmd)).thenThrow(new AttachNotSupportedException("nope"));
+
+      // When / Then
+      assertThatThrownBy(unit::startManagementAgent)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("42");
+    }
+
+    assertThat(unit.isManageable()).isFalse();
+  }
+}


### PR DESCRIPTION
## Problem

Opening a connection to a local JVM by PID failed on the first attempt when the target JVM's management agent wasn't running yet, but succeeded on the second attempt:

```
> open 40197
Managed agent for PID 40197 couldn't start. PID 40197 is not manageable
> open 40197
Connection to 40197 is opened
```

## Root cause

`JavaProcess` caches the local connector address at construction time (read from agent properties in `JavaProcessManager.list()`). `startManagementAgent()` successfully started the agent via `VirtualMachine.startLocalManagementAgent()`, but discarded the connector address that method returns. The subsequent `isManageable()` re-check in `SyntaxUtils.getUrl()` read the stale `null` field and wrongly reported failure. The second `open` rebuilt the process list with fresh agent properties, so it succeeded.

## Fix

- `JavaProcess.startManagementAgent()` now stores the address returned by `startLocalManagementAgent()`, so the first `open <PID>` connects immediately
- The attached `VirtualMachine` is now detached in a `finally` block (was previously leaked)

## Testing

- Added `JavaProcessTest` covering the manageable-state flip after agent start and the attach-failure path
- `mvn verify` passes