### PR TITLE
chore(build): ignore JLS-generated project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ buildNumber.properties
 
 # Misc
 .DS_Store
+
+# JLS
+.classpath
+.factorypath
+.project
+.settings


### PR DESCRIPTION
Adds `.classpath`, `.factorypath`, `.project`, and `.settings` to `.gitignore` to exclude Java Language Server (JLS) generated project files.