### PR TITLE
feat(cmd): add connection aliases for open and -l

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ sudo apt update && sudo apt install jmxsh
 - **Remote & local connections** — connect via host:port, JMX URL, or local PID
 - **JMXMP protocol support** — connect via `jmxmp://host:port` in addition to the default RMI protocol
 - **Full MBean support** — browse domains, read/write attributes, invoke operations
+- **Connection aliases** — name your frequent connection targets with `alias` and reuse them in `open` or `-l`
 - **Command chaining** — run multiple commands in one line with `&&`
 - **Script mode** — automate JMX operations via files or piped input
 - **Quiet mode** — suppress informational messages with `-q` for scripting-friendly output
@@ -102,6 +103,8 @@ $> quit
 | `set <attr> <value>` | Write an MBean attribute |
 | `run <op> [args]` | Invoke an MBean operation |
 | `close` | Disconnect from the JMX endpoint |
+| `alias <name> [target]` | Define, show or list connection aliases |
+| `unalias <name>` | Remove a connection alias |
 | `jvms` | List local Java processes |
 | `help` | Show all available commands |
 
@@ -115,6 +118,28 @@ $> open jmxmp://localhost:9999
 ```
 
 Full service URLs are also supported: `open service:jmx:jmxmp://localhost:9999`
+
+### Connection Aliases
+
+Define short names for connection targets you use often. A target is anything `open`
+accepts: a `host:port`, a PID, a `jmxmp://` address or a full JMX service URL.
+
+```
+$> alias my_server myserver:1234
+#Alias my_server is set to myserver:1234
+$> open my_server
+#Connection to my_server (myserver:1234) is opened
+```
+
+Aliases also work with the `-l` command line option:
+
+```bash
+jmxsh -l my_server
+```
+
+They are stored in `$XDG_CONFIG_HOME/jmxsh/aliases.properties` (default:
+`~/.config/jmxsh/aliases.properties`), which can also be edited by hand. Use `alias` to
+list all aliases and `unalias <name>` to remove one.
 
 ### Non-Interactive Mode
 

--- a/src/main/java/sh/jmx/jmxsh/Session.java
+++ b/src/main/java/sh/jmx/jmxsh/Session.java
@@ -17,6 +17,7 @@ import sh.jmx.jmxsh.io.OutputMode;
 import sh.jmx.jmxsh.io.UnimplementedCommandInput;
 import sh.jmx.jmxsh.io.VerboseCommandOutput;
 import sh.jmx.jmxsh.attach.JavaProcessManager;
+import sh.jmx.jmxsh.utils.AliasStore;
 
 /**
  * JMX communication context. This class exists for the whole lifecycle of a command execution. It
@@ -34,13 +35,15 @@ public class Session {
   private final CommandInput input;
   private final CommandOutput output;
   private final JavaProcessManager processManager;
+  private final AliasStore aliasStore;
   private OutputMode outputMode = OutputMode.BRIEF;
 
   public Session(@NonNull CommandOutput output, CommandInput input,
-      @NonNull JavaProcessManager processManager) {
+      @NonNull JavaProcessManager processManager, @NonNull AliasStore aliasStore) {
     this.output = new VerboseCommandOutput(output, () -> this.outputMode);
     this.input = input == null ? new UnimplementedCommandInput() : input;
     this.processManager = processManager;
+    this.aliasStore = aliasStore;
   }
 
   public void close() {

--- a/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
+++ b/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
@@ -3,6 +3,7 @@ package sh.jmx.jmxsh;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.net.MalformedURLException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Map;
@@ -55,7 +56,16 @@ public final class SyntaxUtils {
     } else if (PATTERN_HOST_PORT.matcher(url).find()) {
       return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + url + "/jmxrmi");
     } else {
-      return new JMXServiceURL(url);
+      try {
+        return new JMXServiceURL(url);
+      } catch (MalformedURLException e) {
+        throw new IllegalArgumentException(
+            "Invalid connection target \""
+                + url
+                + "\". Accepted forms: a <PID>, <host>:<port>, jmxmp://<host>:<port>, a full"
+                + " service:jmx:... URL, or an alias defined with the alias command.",
+            e);
+      }
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
+++ b/src/main/java/sh/jmx/jmxsh/SyntaxUtils.java
@@ -37,36 +37,42 @@ public final class SyntaxUtils {
   public static JMXServiceURL getUrl(String url, JavaProcessManager jpm) throws IOException {
     if (url == null || url.isEmpty()) {
       throw new IllegalArgumentException("Empty URL is not allowed");
-    } else if (isDigits(url) && jpm != null) {
-      int pid = Integer.parseInt(url);
-      JavaProcess p = jpm.get(pid);
-      if (p == null) {
-        throw new NullPointerException("No such PID " + pid);
-      }
-      if (!p.isManageable()) {
-        p.startManagementAgent();
-        if (!p.isManageable()) {
-          throw new IllegalStateException("Managed agent for PID " + pid + " couldn't start. PID " + pid + " is not manageable");
-        }
-      }
-      return new JMXServiceURL(p.toUrl());
-
-    } else if (PATTERN_JMXMP_URL.matcher(url).find()) {
+    }
+    if (isDigits(url) && jpm != null) {
+      return getPidUrl(Integer.parseInt(url), jpm);
+    }
+    if (PATTERN_JMXMP_URL.matcher(url).find()) {
       return new JMXServiceURL("service:jmx:" + url);
-    } else if (PATTERN_HOST_PORT.matcher(url).find()) {
-      return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + url + "/jmxrmi");
-    } else {
-      try {
-        return new JMXServiceURL(url);
-      } catch (MalformedURLException e) {
-        throw new IllegalArgumentException(
-            "Invalid connection target \""
-                + url
-                + "\". Accepted forms: a <PID>, <host>:<port>, jmxmp://<host>:<port>, a full"
-                + " service:jmx:... URL, or an alias defined with the alias command.",
-            e);
+    }
+    if (PATTERN_HOST_PORT.matcher(url).find()) {
+      return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://%s/jmxrmi".formatted(url));
+    }
+    try {
+      return new JMXServiceURL(url);
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(
+          """
+          Invalid connection target "%s". Accepted forms: a <PID>, <host>:<port>, \
+          jmxmp://<host>:<port>, a full service:jmx:... URL, or an alias defined with \
+          the alias command.\
+          """.formatted(url),
+          e);
+    }
+  }
+
+  private static JMXServiceURL getPidUrl(int pid, JavaProcessManager jpm) throws IOException {
+    JavaProcess p = jpm.get(pid);
+    if (p == null) {
+      throw new NullPointerException("No such PID " + pid);
+    }
+    if (!p.isManageable()) {
+      p.startManagementAgent();
+      if (!p.isManageable()) {
+        throw new IllegalStateException(
+            "Managed agent for PID %d couldn't start. PID %d is not manageable".formatted(pid, pid));
       }
     }
+    return new JMXServiceURL(p.toUrl());
   }
 
   public static boolean isNull(String s) {

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -155,8 +155,10 @@ public class CliMain {
               // error
               env.put("com.sun.jndi.rmi.factory.socket", new SslRMIClientSocketFactory());
             }
+            String target =
+                commandCenter.getSession().getAliasStore().resolve(options.getUrl());
             commandCenter.connect(
-                SyntaxUtils.getUrl(options.getUrl(), commandCenter.getProcessManager()),
+                SyntaxUtils.getUrl(target, commandCenter.getProcessManager()),
                 env.isEmpty() ? null : env);
           }
           commandCenter.setOutputMode(outputMode);

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMainOptions.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMainOptions.java
@@ -95,7 +95,7 @@ public class CliMainOptions {
 
   @Option(
       names = {"-l", "--url"},
-      description = "Location of MBean service. It can be <host>:<port>, jmxmp://<host>:<port>, or full service URL.")
+      description = "Location of MBean service. It can be <host>:<port>, jmxmp://<host>:<port>, a full service URL, or an alias defined with the alias command.")
   public final void setUrl(@NonNull String url) {
     this.url = url;
   }

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -21,6 +21,8 @@ import sh.jmx.jmxsh.io.CommandOutput;
 import sh.jmx.jmxsh.io.RuntimeIOException;
 import sh.jmx.jmxsh.io.OutputMode;
 import sh.jmx.jmxsh.attach.JavaProcessManager;
+import sh.jmx.jmxsh.utils.AliasStore;
+import sh.jmx.jmxsh.utils.XdgDirectories;
 
 import org.jline.reader.Parser.ParseContext;
 import org.jline.reader.SyntaxError;
@@ -49,10 +51,21 @@ public class CommandCenter {
   }
 
   /** This constructor is for testing purpose only. */
+  public CommandCenter(CommandOutput output, CommandInput input, @NonNull AliasStore aliasStore) {
+    this(output, input, new PredefinedCommandFactory(), aliasStore);
+  }
+
+  /** This constructor is for testing purpose only. */
   public CommandCenter(@NonNull CommandOutput output, CommandInput input,
       @NonNull CommandFactory commandFactory) {
+    this(output, input, commandFactory, AliasStore.load(XdgDirectories.INSTANCE));
+  }
+
+  /** This constructor is for testing purpose only. */
+  public CommandCenter(@NonNull CommandOutput output, CommandInput input,
+      @NonNull CommandFactory commandFactory, @NonNull AliasStore aliasStore) {
     this.processManager = new JavaProcessManager();
-    this.session = new Session(output, input, processManager);
+    this.session = new Session(output, input, processManager, aliasStore);
     this.commandFactory = commandFactory;
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cc/PredefinedCommandFactory.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/PredefinedCommandFactory.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 
 import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.CommandFactory;
+import sh.jmx.jmxsh.cmd.AliasCommand;
 import sh.jmx.jmxsh.cmd.BeanCommand;
 import sh.jmx.jmxsh.cmd.BeansCommand;
 import sh.jmx.jmxsh.cmd.CloseCommand;
@@ -20,6 +21,7 @@ import sh.jmx.jmxsh.cmd.QuitCommand;
 import sh.jmx.jmxsh.cmd.RunCommand;
 import sh.jmx.jmxsh.cmd.SetCommand;
 import sh.jmx.jmxsh.cmd.SubscribeCommand;
+import sh.jmx.jmxsh.cmd.UnaliasCommand;
 import sh.jmx.jmxsh.cmd.UnsubscribeCommand;
 import sh.jmx.jmxsh.cmd.WatchCommand;
 
@@ -33,6 +35,7 @@ class PredefinedCommandFactory implements CommandFactory {
 
   PredefinedCommandFactory() {
     Map<String, Supplier<Command>> commands = new HashMap<>();
+    commands.put("alias",       AliasCommand::new);
     commands.put("bean",        BeanCommand::new);
     commands.put("beans",       BeansCommand::new);
     commands.put("close",       CloseCommand::new);
@@ -48,6 +51,7 @@ class PredefinedCommandFactory implements CommandFactory {
     commands.put("run",         RunCommand::new);
     commands.put("set",         SetCommand::new);
     commands.put("subscribe",   SubscribeCommand::new);
+    commands.put("unalias",     UnaliasCommand::new);
     commands.put("unsubscribe", UnsubscribeCommand::new);
     commands.put("watch",       WatchCommand::new);
     commands.put("help",        HelpCommand::new);

--- a/src/main/java/sh/jmx/jmxsh/cmd/AliasCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/AliasCommand.java
@@ -46,21 +46,21 @@ public class AliasCommand extends Command {
         return;
       }
       for (Map.Entry<String, String> entry : aliasStore.asMap().entrySet()) {
-        session.getOutput().println(entry.getKey() + " = " + entry.getValue());
+        session.getOutput().println("%s = %s".formatted(entry.getKey(), entry.getValue()));
       }
       return;
     }
     if (target == null) {
       String value = aliasStore.asMap().get(name);
       if (value == null) {
-        throw new IllegalArgumentException("Alias " + name + " is not defined");
+        throw new IllegalArgumentException("Alias %s is not defined".formatted(name));
       }
-      session.getOutput().println(name + " = " + value);
+      session.getOutput().println("%s = %s".formatted(name, value));
       return;
     }
     aliasStore.put(name, target);
     log.debug("defined alias {} = {}", name, target);
-    session.getOutput().printMessage("Alias " + name + " is set to " + target);
+    session.getOutput().printMessage("Alias %s is set to %s".formatted(name, target));
   }
 
   @Parameters(index = "0", paramLabel = "name", description = "Name of the alias", arity = "0..1")

--- a/src/main/java/sh/jmx/jmxsh/cmd/AliasCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/AliasCommand.java
@@ -1,0 +1,79 @@
+package sh.jmx.jmxsh.cmd;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import sh.jmx.jmxsh.Command;
+import sh.jmx.jmxsh.Session;
+import sh.jmx.jmxsh.utils.AliasStore;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
+
+@CommandLine.Command(
+    name = "alias",
+    description = "Define, show or list connection aliases",
+    footer =
+        """
+        Without arguments this command lists all aliases. With a name it shows that alias, \
+        and with a name and a target it defines the alias and persists it to the aliases file. \
+        A target is anything the open command accepts: a PID, <host>:<port>, jmxmp://<host>:<port> \
+        or a full JMX service URL. Use "unalias <name>" to remove an alias. For example
+         alias,
+         alias my_server,
+         alias my_server myserver:1234,
+         alias my_process 5678""")
+@Slf4j
+public class AliasCommand extends Command {
+  private String name;
+
+  private String target;
+
+  @Override
+  public List<String> doSuggestArgument() {
+    return List.copyOf(getSession().getAliasStore().names());
+  }
+
+  @Override
+  public void execute() throws IOException {
+    Session session = getSession();
+    AliasStore aliasStore = session.getAliasStore();
+    if (name == null) {
+      if (aliasStore.asMap().isEmpty()) {
+        session.getOutput().printMessage("no aliases defined");
+        return;
+      }
+      for (Map.Entry<String, String> entry : aliasStore.asMap().entrySet()) {
+        session.getOutput().println(entry.getKey() + " = " + entry.getValue());
+      }
+      return;
+    }
+    if (target == null) {
+      String value = aliasStore.asMap().get(name);
+      if (value == null) {
+        throw new IllegalArgumentException("Alias " + name + " is not defined");
+      }
+      session.getOutput().println(name + " = " + value);
+      return;
+    }
+    aliasStore.put(name, target);
+    log.debug("defined alias {} = {}", name, target);
+    session.getOutput().printMessage("Alias " + name + " is set to " + target);
+  }
+
+  @Parameters(index = "0", paramLabel = "name", description = "Name of the alias", arity = "0..1")
+  public final void setName(String name) {
+    this.name = name;
+  }
+
+  @Parameters(
+      index = "1",
+      paramLabel = "target",
+      description = "Connection target: PID, <host>:<port>, jmxmp://<host>:<port> or JMX service URL",
+      arity = "0..1")
+  public final void setTarget(String target) {
+    this.target = target;
+  }
+}

--- a/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
@@ -74,14 +74,15 @@ public class OpenCommand extends Command {
     try {
       session.connect(
           SyntaxUtils.getUrl(target, session.getProcessManager()), env.isEmpty() ? null : env);
-      String openedTarget = target.equals(url) ? url : url + " (" + target + ")";
-      session.getOutput().printMessage("Connection to " + openedTarget + " is opened");
+      String openedTarget = target.equals(url) ? url : "%s (%s)".formatted(url, target);
+      session.getOutput().printMessage("Connection to %s is opened".formatted(openedTarget));
     } catch (IOException e) {
       if (SyntaxUtils.isDigits(target)) {
         session.getOutput().printMessage(
-            "Couldn't connect to PID "
-                + target
-                + ", it's likely that your version of JDK doesn't allow to connect to a process directly");
+            """
+            Couldn't connect to PID %s, it's likely that your version of JDK doesn't allow \
+            to connect to a process directly\
+            """.formatted(target));
       }
       throw e;
     }

--- a/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
@@ -2,6 +2,7 @@ package sh.jmx.jmxsh.cmd;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.management.remote.JMXConnector;
@@ -23,12 +24,14 @@ import lombok.extern.slf4j.Slf4j;
     footer =
         """
         Without argument this command display current connection. \
-        URL can be a <PID>, <hostname>:<port> or full qualified JMX service URL. \
+        URL can be a <PID>, <hostname>:<port>, full qualified JMX service URL \
+        or an alias defined with the alias command. \
         For JMXMP connections, use jmxmp://<hostname>:<port>. For example
          open localhost:9991,
          open jmxmp://localhost:9991,
          open service:jmx:jmxmp://localhost:9991,
-         open jmx:service:...""")
+         open jmx:service:...,
+         open my_server""")
 @Slf4j
 public class OpenCommand extends Command {
   private String password;
@@ -67,19 +70,26 @@ public class OpenCommand extends Command {
       // Required to prevent "java.rmi.ConnectIOException: non-JRMP server at remote endpoint" error
       env.put("com.sun.jndi.rmi.factory.socket", new SslRMIClientSocketFactory());
     }
+    String target = session.getAliasStore().resolve(url);
     try {
       session.connect(
-          SyntaxUtils.getUrl(url, session.getProcessManager()), env.isEmpty() ? null : env);
-      session.getOutput().printMessage("Connection to " + url + " is opened");
+          SyntaxUtils.getUrl(target, session.getProcessManager()), env.isEmpty() ? null : env);
+      String openedTarget = target.equals(url) ? url : url + " (" + target + ")";
+      session.getOutput().printMessage("Connection to " + openedTarget + " is opened");
     } catch (IOException e) {
-      if (SyntaxUtils.isDigits(url)) {
+      if (SyntaxUtils.isDigits(target)) {
         session.getOutput().printMessage(
             "Couldn't connect to PID "
-                + url
+                + target
                 + ", it's likely that your version of JDK doesn't allow to connect to a process directly");
       }
       throw e;
     }
+  }
+
+  @Override
+  public List<String> doSuggestArgument() {
+    return List.copyOf(getSession().getAliasStore().names());
   }
 
   @Option(
@@ -89,7 +99,7 @@ public class OpenCommand extends Command {
     this.password = password;
   }
 
-  @Parameters(paramLabel = "url", description = "URL, <host>:<port>, jmxmp://<host>:<port>, or a PID to connect to", arity = "0..1")
+  @Parameters(paramLabel = "url", description = "URL, <host>:<port>, jmxmp://<host>:<port>, a PID or an alias to connect to", arity = "0..1")
   public final void setUrl(String url) {
     this.url = url;
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/UnaliasCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/UnaliasCommand.java
@@ -27,10 +27,10 @@ public class UnaliasCommand extends Command {
   public void execute() throws IOException {
     Session session = getSession();
     if (!session.getAliasStore().remove(name)) {
-      throw new IllegalArgumentException("Alias " + name + " is not defined");
+      throw new IllegalArgumentException("Alias %s is not defined".formatted(name));
     }
     log.debug("removed alias {}", name);
-    session.getOutput().printMessage("Alias " + name + " is removed");
+    session.getOutput().printMessage("Alias %s is removed".formatted(name));
   }
 
   @Parameters(paramLabel = "name", description = "Name of the alias to remove", arity = "1")

--- a/src/main/java/sh/jmx/jmxsh/cmd/UnaliasCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/UnaliasCommand.java
@@ -1,0 +1,40 @@
+package sh.jmx.jmxsh.cmd;
+
+import java.io.IOException;
+import java.util.List;
+
+import sh.jmx.jmxsh.Command;
+import sh.jmx.jmxsh.Session;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Parameters;
+import lombok.extern.slf4j.Slf4j;
+
+@CommandLine.Command(
+    name = "unalias",
+    description = "Remove a connection alias",
+    footer = "Removes an alias defined with the alias command. eg. unalias my_server")
+@Slf4j
+public class UnaliasCommand extends Command {
+  private String name;
+
+  @Override
+  public List<String> doSuggestArgument() {
+    return List.copyOf(getSession().getAliasStore().names());
+  }
+
+  @Override
+  public void execute() throws IOException {
+    Session session = getSession();
+    if (!session.getAliasStore().remove(name)) {
+      throw new IllegalArgumentException("Alias " + name + " is not defined");
+    }
+    log.debug("removed alias {}", name);
+    session.getOutput().printMessage("Alias " + name + " is removed");
+  }
+
+  @Parameters(paramLabel = "name", description = "Name of the alias to remove", arity = "1")
+  public final void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/sh/jmx/jmxsh/utils/AliasStore.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/AliasStore.java
@@ -69,9 +69,10 @@ public class AliasStore {
   public void put(@NonNull String name, @NonNull String value) throws IOException {
     if (!isValidName(name)) {
       throw new IllegalArgumentException(
-          "Invalid alias name \""
-              + name
-              + "\": names must start with a letter or underscore and contain only letters, digits, \"_\", \".\" or \"-\"");
+          """
+          Invalid alias name "%s": names must start with a letter or underscore and contain \
+          only letters, digits, "_", "." or "-"\
+          """.formatted(name));
     }
     aliases.put(name, value);
     save();

--- a/src/main/java/sh/jmx/jmxsh/utils/AliasStore.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/AliasStore.java
@@ -1,0 +1,145 @@
+package sh.jmx.jmxsh.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Named aliases for JMX connection targets, persisted in
+ * {@code $XDG_CONFIG_HOME/jmxsh/aliases.properties}. An alias maps a short name to anything the
+ * {@code open} command accepts: a PID, {@code host:port}, {@code jmxmp://host:port} or a full JMX
+ * service URL. The file may also be edited by hand; every mutation rewrites it.
+ */
+@Slf4j
+public class AliasStore {
+
+  /**
+   * Valid alias names can never be mistaken for a connection target: they must not be all digits
+   * (PID) and must not contain {@code :} or {@code /} (host:port, URL).
+   */
+  static final Pattern VALID_NAME = Pattern.compile("^[A-Za-z_][A-Za-z0-9_.-]*$");
+
+  private static final String FILE_HEADER =
+      "# jmxsh connection aliases; managed by the \"alias\" command, hand-editing is OK";
+
+  private final Path file;
+  private final SortedMap<String, String> aliases = new TreeMap<>();
+
+  public AliasStore(@NonNull Path file) {
+    this.file = file;
+    load();
+  }
+
+  /** Loads the alias store from the XDG aliases file for the given directories. */
+  public static AliasStore load(XdgDirectories xdg) {
+    return new AliasStore(xdg.getAliasesFile());
+  }
+
+  /** Returns whether the given string is a valid alias name. */
+  public static boolean isValidName(String name) {
+    return name != null && VALID_NAME.matcher(name).matches();
+  }
+
+  /**
+   * Resolves a connection target: if it is a defined alias name, returns the aliased target,
+   * otherwise returns the input unchanged.
+   */
+  public String resolve(String target) {
+    if (target == null) {
+      return null;
+    }
+    return aliases.getOrDefault(target, target);
+  }
+
+  /** Defines or redefines an alias and persists the change. */
+  public void put(@NonNull String name, @NonNull String value) throws IOException {
+    if (!isValidName(name)) {
+      throw new IllegalArgumentException(
+          "Invalid alias name \""
+              + name
+              + "\": names must start with a letter or underscore and contain only letters, digits, \"_\", \".\" or \"-\"");
+    }
+    aliases.put(name, value);
+    save();
+  }
+
+  /**
+   * Removes an alias and persists the change. Returns false (without touching the file) if the
+   * alias is not defined.
+   */
+  public boolean remove(@NonNull String name) throws IOException {
+    if (aliases.remove(name) == null) {
+      return false;
+    }
+    save();
+    return true;
+  }
+
+  /** Returns an unmodifiable view of all aliases, sorted by name. */
+  public SortedMap<String, String> asMap() {
+    return Collections.unmodifiableSortedMap(aliases);
+  }
+
+  /** Returns all alias names, sorted. */
+  public Set<String> names() {
+    return asMap().keySet();
+  }
+
+  private void load() {
+    if (!Files.isRegularFile(file)) {
+      return;
+    }
+    Properties props = new Properties();
+    try (InputStream in = Files.newInputStream(file)) {
+      props.load(in);
+    } catch (IOException e) {
+      log.warn("failed to read aliases from {}, starting with none", file, e);
+      return;
+    }
+    for (Map.Entry<Object, Object> entry : props.entrySet()) {
+      String name = (String) entry.getKey();
+      if (isValidName(name)) {
+        aliases.put(name, (String) entry.getValue());
+      } else {
+        log.debug("skipping invalid alias name \"{}\" in {}", name, file);
+      }
+    }
+  }
+
+  private void save() throws IOException {
+    Files.createDirectories(file.getParent());
+    StringBuilder content = new StringBuilder(FILE_HEADER).append('\n');
+    for (Map.Entry<String, String> entry : aliases.entrySet()) {
+      content
+          .append(entry.getKey())
+          .append('=')
+          .append(entry.getValue().replace("\\", "\\\\"))
+          .append('\n');
+    }
+    Path temp = Files.createTempFile(file.getParent(), file.getFileName().toString(), ".tmp");
+    try {
+      Files.writeString(temp, content.toString(), StandardCharsets.UTF_8);
+      try {
+        Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (AtomicMoveNotSupportedException _) {
+        Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temp);
+    }
+  }
+}

--- a/src/main/java/sh/jmx/jmxsh/utils/XdgDirectories.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/XdgDirectories.java
@@ -16,6 +16,7 @@ public final class XdgDirectories {
   static final String APP_NAME = "jmxsh";
   static final String HISTORY_FILENAME = "history";
   static final String CONFIG_FILENAME = "config.properties";
+  static final String ALIASES_FILENAME = "aliases.properties";
   static final String LOG_FILENAME = "jmxsh.log";
 
   private final Function<String, String> env;
@@ -62,6 +63,11 @@ public final class XdgDirectories {
   /** Returns the path where the application config file should be stored. */
   public Path getConfigFile() {
     return getConfigHome().resolve(APP_NAME).resolve(CONFIG_FILENAME);
+  }
+
+  /** Returns the path where connection aliases should be stored. */
+  public Path getAliasesFile() {
+    return getConfigHome().resolve(APP_NAME).resolve(ALIASES_FILENAME);
   }
 
   /** Returns the path where the log file should be stored. */

--- a/src/test/java/sh/jmx/jmxsh/SessionTest.java
+++ b/src/test/java/sh/jmx/jmxsh/SessionTest.java
@@ -11,6 +11,7 @@ import javax.management.remote.JMXServiceURL;
 
 import sh.jmx.jmxsh.io.WriterCommandOutput;
 import sh.jmx.jmxsh.attach.JavaProcessManager;
+import sh.jmx.jmxsh.utils.AliasStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,11 +24,14 @@ class SessionTest {
   @Mock
   private JMXConnector con;
 
+  @Mock
+  private AliasStore aliasStore;
+
   private Session session;
 
   @BeforeEach
   void setUp() {
-    session = new Session(new WriterCommandOutput(Writer.nullWriter()), null, new JavaProcessManager()) {
+    session = new Session(new WriterCommandOutput(Writer.nullWriter()), null, new JavaProcessManager(), aliasStore) {
       @Override
       protected JMXConnector doConnect(JMXServiceURL url, Map<String, Object> env) {
         return con;
@@ -45,14 +49,22 @@ class SessionTest {
   @Test
   void constructorThrowsWhenOutputNull() {
     JavaProcessManager processManager = new JavaProcessManager();
-    assertThatThrownBy(() -> new Session(null, null, processManager))
+    assertThatThrownBy(() -> new Session(null, null, processManager, aliasStore))
         .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void constructorThrowsWhenProcessManagerNull() {
     WriterCommandOutput output = new WriterCommandOutput(Writer.nullWriter());
-    assertThatThrownBy(() -> new Session(output, null, null))
+    assertThatThrownBy(() -> new Session(output, null, null, aliasStore))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void constructorThrowsWhenAliasStoreNull() {
+    WriterCommandOutput output = new WriterCommandOutput(Writer.nullWriter());
+    JavaProcessManager processManager = new JavaProcessManager();
+    assertThatThrownBy(() -> new Session(output, null, processManager, null))
         .isInstanceOf(NullPointerException.class);
   }
 

--- a/src/test/java/sh/jmx/jmxsh/SyntaxUtilsTest.java
+++ b/src/test/java/sh/jmx/jmxsh/SyntaxUtilsTest.java
@@ -59,6 +59,17 @@ class SyntaxUtilsTest {
             });
   }
 
+  @Test
+  void should_throw_with_accepted_forms_when_target_invalid() {
+    // When / Then
+    assertThatThrownBy(() -> SyntaxUtils.getUrl("myal", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid connection target \"myal\". Accepted forms: a <PID>, <host>:<port>,"
+                + " jmxmp://<host>:<port>, a full service:jmx:... URL, or an alias defined with"
+                + " the alias command.");
+  }
+
   /** Verify string expression of type is correctly parsed */
   @Test
   void parseNormally() {

--- a/src/test/java/sh/jmx/jmxsh/cc/CommandCenterTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cc/CommandCenterTest.java
@@ -13,8 +13,10 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import sh.jmx.jmxsh.Command;
+import sh.jmx.jmxsh.CommandFactory;
 import sh.jmx.jmxsh.SelfRecordingCommand;
 import sh.jmx.jmxsh.io.WriterCommandOutput;
+import sh.jmx.jmxsh.utils.AliasStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -145,7 +147,14 @@ class CommandCenterTest {
   @Test
   void constructorThrowsWhenCommandFactoryNull() {
     WriterCommandOutput commandOutput = new WriterCommandOutput(new StringWriter());
-    assertThatThrownBy(() -> new CommandCenter(commandOutput, null, null))
+    assertThatThrownBy(() -> new CommandCenter(commandOutput, null, (CommandFactory) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void constructorThrowsWhenAliasStoreNull() {
+    WriterCommandOutput commandOutput = new WriterCommandOutput(new StringWriter());
+    assertThatThrownBy(() -> new CommandCenter(commandOutput, null, (AliasStore) null))
         .isInstanceOf(NullPointerException.class);
   }
 

--- a/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
@@ -1,0 +1,138 @@
+package sh.jmx.jmxsh.cmd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import sh.jmx.jmxsh.Session;
+import sh.jmx.jmxsh.io.WriterCommandOutput;
+import sh.jmx.jmxsh.utils.AliasStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AliasCommandTest {
+
+  @Mock
+  private Session session;
+
+  @Mock
+  private AliasStore aliasStore;
+
+  @Test
+  void should_list_aliases_sorted_when_no_arguments() throws Exception {
+    // Given
+    AliasCommand unit = new AliasCommand();
+    StringWriter writer = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    TreeMap<String, String> aliases = new TreeMap<>();
+    aliases.put("zebra", "zhost:1");
+    aliases.put("apple", "ahost:2");
+    when(aliasStore.asMap()).thenReturn(Collections.unmodifiableSortedMap(aliases));
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(writer.toString())
+        .isEqualTo(
+            "apple = ahost:2" + System.lineSeparator() + "zebra = zhost:1" + System.lineSeparator());
+  }
+
+  @Test
+  void should_print_message_when_no_aliases_defined() throws Exception {
+    // Given
+    AliasCommand unit = new AliasCommand();
+    StringWriter writer = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.asMap()).thenReturn(Collections.emptySortedMap());
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(writer.toString()).isEqualTo("no aliases defined");
+  }
+
+  @Test
+  void should_show_alias_when_name_given() throws Exception {
+    // Given
+    AliasCommand unit = new AliasCommand();
+    StringWriter writer = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    TreeMap<String, String> aliases = new TreeMap<>();
+    aliases.put("my_server", "myserver:1234");
+    when(aliasStore.asMap()).thenReturn(Collections.unmodifiableSortedMap(aliases));
+    unit.setSession(session);
+    unit.setName("my_server");
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(writer.toString()).isEqualTo("my_server = myserver:1234" + System.lineSeparator());
+  }
+
+  @Test
+  void should_throw_when_shown_alias_unknown() {
+    // Given
+    AliasCommand unit = new AliasCommand();
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.asMap()).thenReturn(Collections.emptySortedMap());
+    unit.setSession(session);
+    unit.setName("nope");
+
+    // When / Then
+    assertThatThrownBy(unit::execute)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Alias nope is not defined");
+  }
+
+  @Test
+  void should_define_alias_when_name_and_target_given() throws Exception {
+    // Given
+    AliasCommand unit = new AliasCommand();
+    StringWriter writer = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    unit.setSession(session);
+    unit.setName("my_server");
+    unit.setTarget("myserver:1234");
+
+    // When
+    unit.execute();
+
+    // Then
+    verify(aliasStore).put("my_server", "myserver:1234");
+    assertThat(writer.toString()).isEqualTo("Alias my_server is set to myserver:1234");
+  }
+
+  @Test
+  void should_suggest_alias_names_when_completing() {
+    // Given
+    AliasCommand unit = new AliasCommand();
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.names()).thenReturn(new TreeSet<>(List.of("a", "b")));
+    unit.setSession(session);
+
+    // When
+    List<String> suggestions = unit.doSuggestArgument();
+
+    // Then
+    assertThat(suggestions).containsExactly("a", "b");
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
@@ -45,8 +45,8 @@ class AliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer.toString())
-        .isEqualTo(
+    assertThat(writer)
+        .hasToString(
             "apple = ahost:2" + System.lineSeparator() + "zebra = zhost:1" + System.lineSeparator());
   }
 
@@ -64,7 +64,7 @@ class AliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer.toString()).isEqualTo("no aliases defined");
+    assertThat(writer).hasToString("no aliases defined");
   }
 
   @Test
@@ -84,7 +84,7 @@ class AliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer.toString()).isEqualTo("my_server = myserver:1234" + System.lineSeparator());
+    assertThat(writer).hasToString("my_server = myserver:1234" + System.lineSeparator());
   }
 
   @Test
@@ -118,7 +118,7 @@ class AliasCommandTest {
 
     // Then
     verify(aliasStore).put("my_server", "myserver:1234");
-    assertThat(writer.toString()).isEqualTo("Alias my_server is set to myserver:1234");
+    assertThat(writer).hasToString("Alias my_server is set to myserver:1234");
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/cmd/OpenCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/OpenCommandTest.java
@@ -14,6 +14,7 @@ import sh.jmx.jmxsh.Connection;
 import sh.jmx.jmxsh.Session;
 import sh.jmx.jmxsh.SyntaxUtils;
 import sh.jmx.jmxsh.io.WriterCommandOutput;
+import sh.jmx.jmxsh.utils.AliasStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,8 @@ class OpenCommandTest {
   private Session session;
   @Mock
   private Connection connection;
+  @Mock
+  private AliasStore aliasStore;
 
   private OpenCommand command;
   private StringWriter writer;
@@ -57,9 +60,31 @@ class OpenCommandTest {
   /** @throws Exception */
   @Test
   void executeWithUrl() throws Exception {
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.resolve("xyz.cyclopsgroup.org:12345")).thenReturn("xyz.cyclopsgroup.org:12345");
     command.setUrl("xyz.cyclopsgroup.org:12345");
     command.setSession(session);
     command.execute();
     verify(session).connect(any(JMXServiceURL.class), isNull());
+  }
+
+  @Test
+  void should_connect_to_resolved_target_when_url_is_alias() throws Exception {
+    // Given
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.resolve("my_server")).thenReturn("localhost:9991");
+    command.setUrl("my_server");
+    command.setSession(session);
+
+    // When
+    command.execute();
+
+    // Then
+    verify(session)
+        .connect(new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:9991/jmxrmi"), null);
+    assertThat(messageWriter.toString())
+        .contains("Connection to my_server (localhost:9991) is opened");
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
@@ -1,0 +1,75 @@
+package sh.jmx.jmxsh.cmd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.util.List;
+import java.util.TreeSet;
+
+import sh.jmx.jmxsh.Session;
+import sh.jmx.jmxsh.io.WriterCommandOutput;
+import sh.jmx.jmxsh.utils.AliasStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UnaliasCommandTest {
+
+  @Mock
+  private Session session;
+
+  @Mock
+  private AliasStore aliasStore;
+
+  @Test
+  void should_remove_alias_when_defined() throws Exception {
+    // Given
+    UnaliasCommand unit = new UnaliasCommand();
+    StringWriter writer = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.remove("my_server")).thenReturn(true);
+    unit.setSession(session);
+    unit.setName("my_server");
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(writer.toString()).isEqualTo("Alias my_server is removed");
+  }
+
+  @Test
+  void should_throw_when_alias_unknown() throws Exception {
+    // Given
+    UnaliasCommand unit = new UnaliasCommand();
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.remove("nope")).thenReturn(false);
+    unit.setSession(session);
+    unit.setName("nope");
+
+    // When / Then
+    assertThatThrownBy(unit::execute)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Alias nope is not defined");
+  }
+
+  @Test
+  void should_suggest_alias_names_when_completing() {
+    // Given
+    UnaliasCommand unit = new UnaliasCommand();
+    when(session.getAliasStore()).thenReturn(aliasStore);
+    when(aliasStore.names()).thenReturn(new TreeSet<>(List.of("a", "b")));
+    unit.setSession(session);
+
+    // When
+    List<String> suggestions = unit.doSuggestArgument();
+
+    // Then
+    assertThat(suggestions).containsExactly("a", "b");
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
@@ -40,7 +40,7 @@ class UnaliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer.toString()).isEqualTo("Alias my_server is removed");
+    assertThat(writer).hasToString("Alias my_server is removed");
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/integration/AliasResolutionIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/AliasResolutionIT.java
@@ -1,0 +1,79 @@
+package sh.jmx.jmxsh.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import java.nio.file.Path;
+
+import sh.jmx.jmxsh.cc.CommandCenter;
+import sh.jmx.jmxsh.io.WriterCommandOutput;
+import sh.jmx.jmxsh.utils.AliasStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Integration tests for connection alias definition, resolution and removal. */
+class AliasResolutionIT {
+
+  @RegisterExtension static EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+
+  @TempDir private Path tempDir;
+
+  private CommandCenter cc;
+  private Path aliasesFile;
+  private StringWriter resultWriter;
+  private StringWriter messageWriter;
+
+  @BeforeEach
+  void setUp() {
+    resultWriter = new StringWriter();
+    messageWriter = new StringWriter();
+    aliasesFile = tempDir.resolve("aliases.properties");
+    cc = new CommandCenter(
+        new WriterCommandOutput(resultWriter, messageWriter), null, new AliasStore(aliasesFile));
+  }
+
+  @AfterEach
+  void tearDown() {
+    cc.close();
+  }
+
+  @Test
+  void testOpenResolvesAlias() {
+    assertThat(cc.execute("alias my_server " + jmxServer.getConnectionUrl())).isTrue();
+    assertThat(cc.execute("open my_server")).isTrue();
+    assertThat(cc.execute("domains")).isTrue();
+    assertThat(cc.execute("close")).isTrue();
+  }
+
+  @Test
+  void testAliasPersistsToFile() {
+    assertThat(cc.execute("alias my_server " + jmxServer.getConnectionUrl())).isTrue();
+    assertThat(aliasesFile).exists();
+    assertThat(new AliasStore(aliasesFile).resolve("my_server"))
+        .isEqualTo(jmxServer.getConnectionUrl());
+  }
+
+  @Test
+  void testAliasListAndRemove() {
+    assertThat(cc.execute("alias my_server " + jmxServer.getConnectionUrl())).isTrue();
+    resultWriter.getBuffer().setLength(0);
+    assertThat(cc.execute("alias")).isTrue();
+    assertThat(resultWriter.toString())
+        .contains("my_server = " + jmxServer.getConnectionUrl());
+    assertThat(cc.execute("unalias my_server")).isTrue();
+    assertThat(new AliasStore(aliasesFile).names()).isEmpty();
+  }
+
+  @Test
+  void testUnaliasFailsForUnknownName() {
+    assertThat(cc.execute("unalias no_such_alias")).isFalse();
+  }
+
+  @Test
+  void testAliasRejectsInvalidName() {
+    assertThat(cc.execute("alias 1234 localhost:9991")).isFalse();
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/utils/AliasStoreTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/AliasStoreTest.java
@@ -1,0 +1,199 @@
+package sh.jmx.jmxsh.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AliasStoreTest {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void should_return_stored_value_when_alias_defined() throws Exception {
+    // Given
+    AliasStore unit = new AliasStore(tempDir.resolve("aliases.properties"));
+    unit.put("my_server", "myserver:1234");
+
+    // When
+    String resolved = unit.resolve("my_server");
+
+    // Then
+    assertThat(resolved).isEqualTo("myserver:1234");
+  }
+
+  @Test
+  void should_return_input_unchanged_when_alias_unknown() {
+    // Given
+    AliasStore unit = new AliasStore(tempDir.resolve("aliases.properties"));
+
+    // When
+    String resolved = unit.resolve("localhost:9991");
+
+    // Then
+    assertThat(resolved).isEqualTo("localhost:9991");
+  }
+
+  @Test
+  void should_return_null_when_resolving_null() {
+    // Given
+    AliasStore unit = new AliasStore(tempDir.resolve("aliases.properties"));
+
+    // When
+    String resolved = unit.resolve(null);
+
+    // Then
+    assertThat(resolved).isNull();
+  }
+
+  @Test
+  void should_persist_sorted_entries_when_put_called() throws Exception {
+    // Given
+    Path file = tempDir.resolve("aliases.properties");
+    AliasStore unit = new AliasStore(file);
+
+    // When
+    unit.put("zebra", "zhost:1");
+    unit.put("apple", "ahost:2");
+
+    // Then
+    assertThat(file)
+        .hasContent(
+            """
+            # jmxsh connection aliases; managed by the "alias" command, hand-editing is OK
+            apple=ahost:2
+            zebra=zhost:1""");
+  }
+
+  @Test
+  void should_load_hand_edited_file_when_present() throws Exception {
+    // Given
+    Path file = tempDir.resolve("aliases.properties");
+    Files.writeString(file, "# a comment\nmy_server=service:jmx:rmi:///jndi/rmi://h:1/jmxrmi\n");
+
+    // When
+    AliasStore unit = new AliasStore(file);
+
+    // Then
+    assertThat(unit.resolve("my_server")).isEqualTo("service:jmx:rmi:///jndi/rmi://h:1/jmxrmi");
+  }
+
+  @Test
+  void should_skip_invalid_keys_when_loading() throws Exception {
+    // Given
+    Path file = tempDir.resolve("aliases.properties");
+    Files.writeString(file, "1234=host:1\nvalid_name=host:2\n");
+
+    // When
+    AliasStore unit = new AliasStore(file);
+
+    // Then
+    assertThat(unit.names()).containsExactly("valid_name");
+  }
+
+  @Test
+  void should_throw_when_name_is_all_digits() {
+    // Given
+    AliasStore unit = new AliasStore(tempDir.resolve("aliases.properties"));
+
+    // When / Then
+    assertThatThrownBy(() -> unit.put("1234", "host:1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("1234");
+  }
+
+  @Test
+  void should_throw_when_name_contains_colon() {
+    // Given
+    AliasStore unit = new AliasStore(tempDir.resolve("aliases.properties"));
+
+    // When / Then
+    assertThatThrownBy(() -> unit.put("host:1", "host:1"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void should_throw_when_name_contains_slash() {
+    // Given
+    AliasStore unit = new AliasStore(tempDir.resolve("aliases.properties"));
+
+    // When / Then
+    assertThatThrownBy(() -> unit.put("jmxmp://h", "host:1"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void should_accept_valid_names_when_validating() {
+    assertThat(AliasStore.isValidName("my_server")).isTrue();
+    assertThat(AliasStore.isValidName("_x")).isTrue();
+    assertThat(AliasStore.isValidName("a.b-c")).isTrue();
+    assertThat(AliasStore.isValidName("Server1")).isTrue();
+  }
+
+  @Test
+  void should_reject_invalid_names_when_validating() {
+    assertThat(AliasStore.isValidName(null)).isFalse();
+    assertThat(AliasStore.isValidName("")).isFalse();
+    assertThat(AliasStore.isValidName("1abc")).isFalse();
+    assertThat(AliasStore.isValidName("a b")).isFalse();
+  }
+
+  @Test
+  void should_return_false_when_removing_unknown_alias() throws Exception {
+    // Given
+    Path file = tempDir.resolve("aliases.properties");
+    AliasStore unit = new AliasStore(file);
+
+    // When
+    boolean removed = unit.remove("nope");
+
+    // Then
+    assertThat(removed).isFalse();
+    assertThat(file).doesNotExist();
+  }
+
+  @Test
+  void should_persist_removal_when_alias_exists() throws Exception {
+    // Given
+    Path file = tempDir.resolve("aliases.properties");
+    AliasStore unit = new AliasStore(file);
+    unit.put("my_server", "host:1");
+
+    // When
+    boolean removed = unit.remove("my_server");
+
+    // Then
+    assertThat(removed).isTrue();
+    assertThat(new AliasStore(file).names()).isEmpty();
+  }
+
+  @Test
+  void should_start_empty_when_file_missing() {
+    // When
+    AliasStore unit = new AliasStore(tempDir.resolve("does-not-exist.properties"));
+
+    // Then
+    assertThat(unit.asMap()).isEmpty();
+  }
+
+  @Test
+  void should_round_trip_backslashes_when_saving() throws Exception {
+    // Given
+    Path file = tempDir.resolve("aliases.properties");
+    AliasStore unit = new AliasStore(file);
+
+    // When
+    unit.put("weird", "value\\with\\backslashes");
+
+    // Then
+    assertThat(new AliasStore(file).resolve("weird")).isEqualTo("value\\with\\backslashes");
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/utils/XdgDirectoriesTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/XdgDirectoriesTest.java
@@ -71,6 +71,19 @@ class XdgDirectoriesTest {
   }
 
   @Test
+  void aliasesFileResolvesUnderConfigHome() {
+    var dirs = new XdgDirectories(k -> k.equals("XDG_CONFIG_HOME") ? "/xdg/config" : null, "/ignored");
+    assertThat(dirs.getAliasesFile()).isEqualTo(Path.of("/xdg/config/jmxsh/aliases.properties"));
+  }
+
+  @Test
+  void aliasesFileUsesDefaultConfigHome() {
+    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    assertThat(dirs.getAliasesFile())
+        .isEqualTo(Path.of("/home/testuser/.config/jmxsh/aliases.properties"));
+  }
+
+  @Test
   void logFileResolvesUnderStateHome() {
     var dirs = new XdgDirectories(k -> k.equals("XDG_STATE_HOME") ? "/xdg/state" : null, "/ignored");
     assertThat(dirs.getLogFile()).isEqualTo(Path.of("/xdg/state/jmxsh/logs/jmxsh.log"));


### PR DESCRIPTION
## What

Adds named aliases for JMX connection targets:

```
$> alias my_server myserver:1234
#Alias my_server is set to myserver:1234
$> open my_server
#Connection to my_server (myserver:1234) is opened
$> alias            # list
$> unalias my_server
$ jmxsh -l my_server  # startup option resolves aliases too
```

An alias target is anything `open` accepts today: a PID, `host:port`, `jmxmp://host:port` or a full JMX service URL.

## How

- **`AliasStore`** (new, `sh.jmx.jmxsh.utils`): loads, resolves and persists aliases. Resolution is an exact-name lookup that returns the input unchanged on a miss, so existing `open` behavior is untouched. Names must match `[A-Za-z_][A-Za-z0-9_.-]*`, which structurally rules out collisions with PIDs (no leading digit) and URLs/host:port (no `:` or `/`); invalid keys in a hand-edited file are skipped on load.
- **Storage**: `$XDG_CONFIG_HOME/jmxsh/aliases.properties` — deliberately a separate file from `config.properties`, because the `alias` command rewrites it on every change and rewriting the main config would destroy its hand-written comments. Written manually (sorted `name=target` lines, one header comment, atomic temp-file move) instead of `Properties.store` to keep the file stable, diff-able and hand-editable; read with `Properties.load` so hand-edited escapes still work.
- **`alias` / `unalias` commands** (new): list/show/define and remove, both with tab completion of alias names. `open <TAB>` also suggests alias names.
- **Wiring**: the store is constructor-injected into `Session` (like `JavaProcessManager`); `CommandCenter` creates it from the XDG path by default and gains an overload accepting a custom store for hermetic tests.
- **Startup**: `CliMain` resolves the `-l/--url` value through the same store before `SyntaxUtils.getUrl(...)`.

## Notes for review

- `mvn verify` is green: 256 unit tests + 68 IT/E2E. New coverage: `AliasStoreTest` (15 cases), `AliasCommandTest`, `UnaliasCommandTest`, an alias-resolution case in `OpenCommandTest`, and `AliasResolutionIT` against the embedded JMX server. Also smoke-tested the uber-jar manually with an isolated `XDG_CONFIG_HOME`.
- Pre-existing integration tests using the 2-arg `CommandCenter` constructor now read the developer's real aliases file (read-only, never written); the new store-injecting overload exists for hermetic tests.
- Cosmetic quirk: `ConsoleCompleter` offers positional suggestions for every slot, so alias names also appear when completing the *target* argument of `alias`.
- Two concurrent jmxsh processes writing aliases: last write wins; the atomic move prevents file corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)