### PR TITLE
fix: consistent sentence-style console messages on all quit paths and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,24 +71,25 @@ sudo apt update && sudo apt install jmxsh
 $ java -jar jmxsh-<version>.jar
 Welcome to jmx.sh, type "help" for available commands.
 > open localhost:9999
-Connection to localhost:9999 is opened
+Connection to localhost:9999 is opened.
 > domains
-following domains are available
+The following domains are available:
 JMImplementation
 java.lang
 com.example
 > bean com.example:type=AppStats
-bean is set to com.example:type=AppStats
+Bean is set to com.example:type=AppStats.
 > get RequestCount
-mbean = com.example:type=AppStats:
+MBean = com.example:type=AppStats:
 RequestCount = 42;
 > run resetStats
-calling operation resetStats of mbean com.example:type=AppStats with params []
-operation returns:
+Calling operation resetStats of mbean com.example:type=AppStats with params [].
+Operation returns:
 null
 > close
-disconnected
+Disconnected.
 > quit
+Bye.
 ```
 
 ### Key Commands
@@ -122,7 +123,7 @@ To connect using the JMXMP protocol instead of the default RMI:
 
 ```
 $> open jmxmp://localhost:9999
-#Connection to jmxmp://localhost:9999 is opened
+#Connection to jmxmp://localhost:9999 is opened.
 ```
 
 Full service URLs are also supported: `open service:jmx:jmxmp://localhost:9999`
@@ -134,9 +135,9 @@ accepts: a `host:port`, a PID, a `jmxmp://` address or a full JMX service URL.
 
 ```
 $> alias my_server myserver:1234
-#Alias my_server is set to myserver:1234
+#Alias my_server is set to myserver:1234.
 $> open my_server
-#Connection to my_server (myserver:1234) is opened
+#Connection to my_server (myserver:1234) is opened.
 ```
 
 Aliases also work with the `-l` command line option:
@@ -156,7 +157,7 @@ printf-style format, poll interval (`-i`, in seconds) and duration (`-s`, stop a
 
 ```
 > bean java.lang:type=Memory
-bean is set to java.lang:type=Memory
+Bean is set to java.lang:type=Memory.
 > watch -i 5 HeapMemoryUsage
 ```
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -35,7 +35,7 @@ sequenceDiagram
         S->>S: JMXConnectorFactory.connect()
         S-->>CC: connected (Connection record stored)
         CC-->>CLI: true (success)
-        CLI-->>User: Connection to localhost:9999 is opened
+        CLI-->>User: Connection to localhost:9999 is opened.
 
         User->>CLI: bean test:type=TestMBean
         CLI->>CC: execute("bean test:type=TestMBean")
@@ -46,7 +46,7 @@ sequenceDiagram
         MBS-->>CC: MBeanInfo (validates bean exists)
         CC->>S: setBean(objectName)
         CC-->>CLI: true
-        CLI-->>User: bean is set to test:type=TestMBean
+        CLI-->>User: Bean is set to test:type=TestMBean.
 
         User->>CLI: run echo hello
         CLI->>CC: execute("run echo hello")
@@ -68,7 +68,7 @@ sequenceDiagram
         CC->>S: disconnect()
         S->>S: close JMXConnector (via Connection record)
         CC-->>CLI: true
-        CLI-->>User: disconnected
+        CLI-->>User: Disconnected.
     end
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,24 +96,25 @@ sudo apt update &amp;&amp; sudo apt install jmxsh</code></pre>
 <pre><span class="prompt">$</span> jmxsh
 Welcome to jmx.sh, type "help" for available commands.
 <span class="prompt">&gt;</span> open localhost:9999
-<span class="comment">Connection to localhost:9999 is opened</span>
+<span class="comment">Connection to localhost:9999 is opened.</span>
 <span class="prompt">&gt;</span> domains
-<span class="comment">following domains are available</span>
+<span class="comment">The following domains are available:</span>
 JMImplementation
 java.lang
 com.example
 <span class="prompt">&gt;</span> bean com.example:type=AppStats
-<span class="comment">bean is set to com.example:type=AppStats</span>
+<span class="comment">Bean is set to com.example:type=AppStats.</span>
 <span class="prompt">&gt;</span> get RequestCount
-<span class="comment">mbean = com.example:type=AppStats:</span>
+<span class="comment">MBean = com.example:type=AppStats:</span>
 RequestCount = 42;
 <span class="prompt">&gt;</span> run resetStats
-<span class="comment">calling operation resetStats of mbean com.example:type=AppStats with params []</span>
-<span class="comment">operation returns:</span>
+<span class="comment">Calling operation resetStats of mbean com.example:type=AppStats with params [].</span>
+<span class="comment">Operation returns:</span>
 null
 <span class="prompt">&gt;</span> close
-<span class="comment">disconnected</span>
-<span class="prompt">&gt;</span> quit</pre>
+<span class="comment">Disconnected.</span>
+<span class="prompt">&gt;</span> quit
+<span class="comment">Bye.</span></pre>
         </div>
       </div>
     </div>

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -27,6 +27,7 @@ import sh.jmx.jmxsh.io.OutputMode;
 import sh.jmx.jmxsh.utils.AppConfig;
 import sh.jmx.jmxsh.utils.PromptTemplate;
 import sh.jmx.jmxsh.utils.XdgDirectories;
+import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.LineReaderBuilder;
@@ -162,7 +163,8 @@ public class CliMain {
                 env.isEmpty() ? null : env);
           }
           commandCenter.setOutputMode(outputMode);
-          if (!options.isQuiet() && !options.isNonInteractive()) {
+          boolean interactive = !options.isQuiet() && !options.isNonInteractive();
+          if (interactive) {
             output.printMessage("Welcome to jmx.sh, type \"help\" for available commands.");
           }
           String line;
@@ -171,8 +173,10 @@ public class CliMain {
           while (true) {
             try {
               line = input.readLine();
-            } catch (UserInterruptException _) {
-              output.printMessage("Interrupted.");
+            } catch (UserInterruptException | EndOfFileException _) {
+              if (interactive) {
+                output.printMessage("Bye.");
+              }
               break;
             }
             if (line == null) {

--- a/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
+++ b/src/main/java/sh/jmx/jmxsh/boot/CliMain.java
@@ -163,35 +163,7 @@ public class CliMain {
                 env.isEmpty() ? null : env);
           }
           commandCenter.setOutputMode(outputMode);
-          boolean interactive = !options.isQuiet() && !options.isNonInteractive();
-          if (interactive) {
-            output.printMessage("Welcome to jmx.sh, type \"help\" for available commands.");
-          }
-          String line;
-          int exitCode = 0;
-          int lineNumber = 0;
-          while (true) {
-            try {
-              line = input.readLine();
-            } catch (UserInterruptException | EndOfFileException _) {
-              if (interactive) {
-                output.printMessage("Bye.");
-              }
-              break;
-            }
-            if (line == null) {
-              break;
-            }
-            lineNumber++;
-            if (!commandCenter.execute(line) && options.isExitOnFailure()) {
-              exitCode = -lineNumber;
-              break;
-            }
-            if (commandCenter.isClosed()) {
-              break;
-            }
-          }
-          return exitCode;
+          return runCommandLoop(input, output, commandCenter, options);
         } finally {
           commandCenter.close();
         }
@@ -203,6 +175,45 @@ public class CliMain {
       output.printError(e);
       return 1;
     }
+  }
+
+  /**
+   * Reads and executes commands until the input is exhausted, the user quits or a command fails
+   * with {@code --exitonfailure} enabled. In an interactive session the same "Bye." message is
+   * printed whether the user leaves with Ctrl+C, Ctrl+D or the quit command.
+   */
+  static int runCommandLoop(
+      CommandInput input, CommandOutput output, CommandCenter commandCenter, CliMainOptions options)
+      throws IOException {
+    boolean interactive = !options.isQuiet() && !options.isNonInteractive();
+    if (interactive) {
+      output.printMessage("Welcome to jmx.sh, type \"help\" for available commands.");
+    }
+    String line;
+    int exitCode = 0;
+    int lineNumber = 0;
+    while (true) {
+      try {
+        line = input.readLine();
+      } catch (UserInterruptException | EndOfFileException _) {
+        if (interactive) {
+          output.printMessage("Bye.");
+        }
+        break;
+      }
+      if (line == null) {
+        break;
+      }
+      lineNumber++;
+      if (!commandCenter.execute(line) && options.isExitOnFailure()) {
+        exitCode = -lineNumber;
+        break;
+      }
+      if (commandCenter.isClosed()) {
+        break;
+      }
+    }
+    return exitCode;
   }
 
   /**

--- a/src/main/java/sh/jmx/jmxsh/cmd/AliasCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/AliasCommand.java
@@ -42,7 +42,7 @@ public class AliasCommand extends Command {
     AliasStore aliasStore = session.getAliasStore();
     if (name == null) {
       if (aliasStore.asMap().isEmpty()) {
-        session.getOutput().printMessage("no aliases defined");
+        session.getOutput().printMessage("No aliases defined.");
         return;
       }
       for (Map.Entry<String, String> entry : aliasStore.asMap().entrySet()) {
@@ -60,7 +60,7 @@ public class AliasCommand extends Command {
     }
     aliasStore.put(name, target);
     log.debug("defined alias {} = {}", name, target);
-    session.getOutput().printMessage("Alias %s is set to %s".formatted(name, target));
+    session.getOutput().printMessage("Alias %s is set to %s.".formatted(name, target));
   }
 
   @Parameters(index = "0", paramLabel = "name", description = "Name of the alias", arity = "0..1")

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeanCommand.java
@@ -110,12 +110,12 @@ public class BeanCommand extends Command {
     String beanName = getBeanName(bean, domain, session);
     if (beanName == null) {
       session.setBean(null);
-      session.getOutput().printMessage("bean is unset");
+      session.getOutput().printMessage("Bean is unset.");
       return;
     }
     session.setBean(beanName);
     log.debug("selected bean: {}", beanName);
-    session.getOutput().printMessage("bean is set to " + beanName);
+    session.getOutput().printMessage("Bean is set to %s.".formatted(beanName));
     int colonIdx = beanName.indexOf(':');
     if (colonIdx > 0) {
       session.setDomain(beanName.substring(0, colonIdx));

--- a/src/main/java/sh/jmx/jmxsh/cmd/BeansCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/BeansCommand.java
@@ -51,7 +51,7 @@ public class BeansCommand extends Command {
       domains.add(domainName);
     }
     for (String d : domains) {
-      session.getOutput().printMessage("domain = " + d + ":");
+      session.getOutput().printMessage("Domain = %s:".formatted(d));
       for (String bean : getBeans(session, d)) {
         session.getOutput().println(bean);
       }

--- a/src/main/java/sh/jmx/jmxsh/cmd/CloseCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/CloseCommand.java
@@ -13,6 +13,6 @@ public class CloseCommand extends Command {
   public void execute() throws IOException {
     log.info("closing JMX connection");
     getSession().disconnect();
-    getSession().getOutput().printMessage("disconnected");
+    getSession().getOutput().printMessage("Disconnected.");
   }
 }

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainCommand.java
@@ -51,10 +51,10 @@ public class DomainCommand extends Command {
     Session session = getSession();
     if (domain == null) {
       if (session.getDomain() == null) {
-        session.getOutput().printMessage("domain is not set");
+        session.getOutput().printMessage("Domain is not set.");
         session.getOutput().println(ValueFormat.NULL);
       } else {
-        session.getOutput().printMessage("domain = " + session.getDomain());
+        session.getOutput().printMessage("Domain = " + session.getDomain());
         session.getOutput().println(session.getDomain());
       }
       return;
@@ -62,7 +62,7 @@ public class DomainCommand extends Command {
     String domainName = getDomainName(domain, session);
     if (domainName == null) {
       session.unsetDomain();
-      session.getOutput().printMessage("domain is unset");
+      session.getOutput().printMessage("Domain is unset.");
     } else {
       String currentBean = session.getBean();
       if (currentBean != null) {
@@ -70,12 +70,12 @@ public class DomainCommand extends Command {
         String beanDomain = colonIdx > 0 ? currentBean.substring(0, colonIdx) : null;
         if (!domainName.equals(beanDomain)) {
           session.setBean(null);
-          session.getOutput().printMessage("bean was unset (not part of domain " + domainName + ")");
+          session.getOutput().printMessage("Bean was unset (not part of domain %s).".formatted(domainName));
         }
       }
       session.setDomain(domainName);
       log.debug("selected domain: {}", domainName);
-      session.getOutput().printMessage("domain is set to " + session.getDomain());
+      session.getOutput().printMessage("Domain is set to %s.".formatted(session.getDomain()));
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainsCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainsCommand.java
@@ -26,7 +26,7 @@ public class DomainsCommand extends Command {
   public void execute() throws IOException {
     Session session = getSession();
 
-    session.getOutput().printMessage("following domains are available");
+    session.getOutput().printMessage("The following domains are available:");
     for (String domain : getCandidateDomains(session)) {
       session.getOutput().println(domain);
     }

--- a/src/main/java/sh/jmx/jmxsh/cmd/DomainsCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/DomainsCommand.java
@@ -17,7 +17,7 @@ public class DomainsCommand extends Command {
     try {
       domains = session.getConnection().getServerConnection().getDomains();
     } catch (IOException e) {
-      throw new RuntimeIOException("Couldn't get candate domains", e);
+      throw new RuntimeIOException("Couldn't get candidate domains.", e);
     }
     return Stream.of(domains).sorted().toList();
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/GetCommand.java
@@ -55,7 +55,7 @@ public class GetCommand extends DomainBeanAwareCommand {
     Session session = getSession();
     String beanName = BeanCommand.getBeanName(bean, domain, session);
     ObjectName name = new ObjectName(beanName);
-    session.getOutput().printMessage("mbean = " + beanName + ":");
+    session.getOutput().printMessage("MBean = %s:".formatted(beanName));
     MBeanServerConnection con = session.getConnection().getServerConnection();
     MBeanAttributeInfo[] ais = con.getMBeanInfo(name).getAttributes();
     Map<String, MBeanAttributeInfo> attributeNames = resolveAttributeNames(ais);
@@ -66,7 +66,7 @@ public class GetCommand extends DomainBeanAwareCommand {
       if (i.isReadable()) {
         displayAttribute(con, name, beanName, entry.getKey(), i, fetchedValues, format);
       } else {
-        session.getOutput().printMessage(i.getName() + " is not readable");
+        session.getOutput().printMessage("Attribute %s is not readable.".formatted(i.getName()));
       }
     }
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/InfoCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/InfoCommand.java
@@ -51,7 +51,7 @@ public class InfoCommand extends Command {
     Session session = getSession();
     MBeanAttributeInfo[] attrInfos = info.getAttributes();
     if (attrInfos.length == 0) {
-      session.getOutput().printMessage("there is no attribute");
+      session.getOutput().printMessage("There are no attributes.");
       return;
     }
     int index = 0;
@@ -73,7 +73,7 @@ public class InfoCommand extends Command {
     Session session = getSession();
     MBeanNotificationInfo[] notificationInfos = info.getNotifications();
     if (notificationInfos.length == 0) {
-      session.getOutput().printMessage("there's no notifications");
+      session.getOutput().printMessage("There are no notifications.");
       return;
     }
     int index = 0;
@@ -92,7 +92,7 @@ public class InfoCommand extends Command {
     Session session = getSession();
     MBeanOperationInfo[] operationInfos = info.getOperations();
     if (operationInfos.length == 0) {
-      session.getOutput().printMessage("there's no operations");
+      session.getOutput().printMessage("There are no operations.");
       return;
     }
     List<MBeanOperationInfo> operations = Stream.of(operationInfos).sorted(INFO_COMPARATOR).toList();
@@ -124,7 +124,7 @@ public class InfoCommand extends Command {
     Session session = getSession();
     MBeanOperationInfo[] operationInfos = info.getOperations();
     if (operationInfos.length == 0) {
-      session.getOutput().printMessage("there's no operations");
+      session.getOutput().printMessage("There are no operations.");
       return;
     }
     session.getOutput().println(TEXT_OPERATIONS);
@@ -173,10 +173,10 @@ public class InfoCommand extends Command {
     ObjectName name = new ObjectName(beanName);
     MBeanServerConnection con = session.getConnection().getServerConnection();
     MBeanInfo info = con.getMBeanInfo(name);
-    session.getOutput().printMessage("mbean = " + beanName);
-    session.getOutput().printMessage("class name = " + info.getClassName());
+    session.getOutput().printMessage("MBean = " + beanName);
+    session.getOutput().printMessage("Class name = " + info.getClassName());
     if (this.showDescription) {
-      session.getOutput().printMessage("description: " + info.getDescription());
+      session.getOutput().printMessage("Description: " + info.getDescription());
     }
     if (operation == null) {
       for (char t : type.toCharArray()) {
@@ -189,7 +189,7 @@ public class InfoCommand extends Command {
         }
       }
     } else {
-      session.getOutput().printMessage("operation = " + operation);
+      session.getOutput().printMessage("Operation = " + operation);
       displaySingleOperation(info);
     }
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/OpenCommand.java
@@ -52,7 +52,7 @@ public class OpenCommand extends Command {
     if (url == null) {
       Connection con = session.getConnection();
       if (con == null) {
-        session.getOutput().printMessage("not connected");
+        session.getOutput().printMessage("Not connected.");
         session.getOutput().println(ValueFormat.NULL);
       } else {
         session.getOutput().println("%s,%s".formatted(con.getConnectorId(), con.url()));
@@ -77,13 +77,13 @@ public class OpenCommand extends Command {
       session.connect(
           jmxUrl.toServiceUrl(session.getProcessManager()), env.isEmpty() ? null : env);
       String openedTarget = target.equals(url) ? url : "%s (%s)".formatted(url, target);
-      session.getOutput().printMessage("Connection to %s is opened".formatted(openedTarget));
+      session.getOutput().printMessage("Connection to %s is opened.".formatted(openedTarget));
     } catch (IOException e) {
       if (jmxUrl instanceof JmxUrl.Pid) {
         session.getOutput().printMessage(
             """
             Couldn't connect to PID %s, it's likely that your version of JDK doesn't allow \
-            to connect to a process directly\
+            to connect to a process directly.\
             """.formatted(target));
       }
       throw e;

--- a/src/main/java/sh/jmx/jmxsh/cmd/QuitCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/QuitCommand.java
@@ -13,6 +13,6 @@ public class QuitCommand extends Command {
     Session session = getSession();
     session.disconnect();
     session.close();
-    session.getOutput().printMessage("bye");
+    session.getOutput().printMessage("Bye.");
   }
 }

--- a/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/RunCommand.java
@@ -142,7 +142,7 @@ public class RunCommand extends Command {
       signatures[i] = paramInfo.getType();
     }
     session.getOutput().printMessage(
-        "calling operation %s of mbean %s with params %s".formatted(
+        "Calling operation %s of mbean %s with params %s.".formatted(
             operationName, beanName, Arrays.toString(params)));
 
     Object result;
@@ -152,12 +152,12 @@ public class RunCommand extends Command {
         result = con.invoke(name, operationName, params, signatures);
       } finally {
         long latency = (System.nanoTime() - start) / 1_000_000;
-        session.getOutput().printMessage(latency + "ms is taken by invocation");
+        session.getOutput().printMessage("Invocation took %sms.".formatted(latency));
       }
     } else {
       result = con.invoke(name, operationName, params, signatures);
     }
-    session.getOutput().printMessage("operation returns: ");
+    session.getOutput().printMessage("Operation returns: ");
     new ValueOutputFormat(2, false, showQuotationMarks).printValue(session.getOutput(), result);
     session.getOutput().println("");
   }

--- a/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SetCommand.java
@@ -78,7 +78,7 @@ public class SetCommand extends DomainBeanAwareCommand {
     }
     Object value = valueParser.parse(inputValue, attributeInfo.getType());
     con.setAttribute(name, new Attribute(attributeName, value));
-    session.getOutput().printMessage("Value of attribute " + attributeName + " is set to " + inputValue);
+    session.getOutput().printMessage("Value of attribute %s is set to %s.".formatted(attributeName, inputValue));
   }
 
   @Parameters(description = "name, value, value2...", arity = "2..*")

--- a/src/main/java/sh/jmx/jmxsh/cmd/SubscribeCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/SubscribeCommand.java
@@ -77,7 +77,7 @@ public class SubscribeCommand extends Command {
       con.addNotificationListener(name, listener, null, null);
       listeners.put(name, listener);
 
-      session.getOutput().printMessage("Subscribed to " + name);
+      session.getOutput().printMessage("Subscribed to %s.".formatted(name));
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/UnaliasCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/UnaliasCommand.java
@@ -30,7 +30,7 @@ public class UnaliasCommand extends Command {
       throw new IllegalArgumentException("Alias %s is not defined".formatted(name));
     }
     log.debug("removed alias {}", name);
-    session.getOutput().printMessage("Alias %s is removed".formatted(name));
+    session.getOutput().printMessage("Alias %s is removed.".formatted(name));
   }
 
   @Parameters(paramLabel = "name", description = "Name of the alias to remove", arity = "1")

--- a/src/main/java/sh/jmx/jmxsh/cmd/UnsubscribeCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/UnsubscribeCommand.java
@@ -44,7 +44,7 @@ public class UnsubscribeCommand extends Command {
       MBeanServerConnection con = session.getConnection().getServerConnection();
       con.removeNotificationListener(name, listener);
 
-      session.getOutput().printMessage("Unsubscribed from " + name);
+      session.getOutput().printMessage("Unsubscribed from %s.".formatted(name));
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -105,7 +105,7 @@ public class WatchCommand extends Command {
         console.getTerminal().writer().print(line);
         console.flush();
       };
-      getSession().getOutput().printMessage("press any key to stop. DO NOT press Ctrl+C !!!");
+      getSession().getOutput().printMessage("Press any key to stop. DO NOT press Ctrl+C.");
     }
 
     final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();

--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -75,7 +75,7 @@ public class WatchCommand extends Command {
   public void execute() throws IOException, JMException {
     if (report && stopAfter == 0) {
       throw new IllegalArgumentException(
-          "When --report is sepcified, --stopafter(-s) must be specificed");
+          "When --report is specified, --stopafter(-s) must be specified.");
     }
     Session session = getSession();
     String domain = DomainCommand.getDomainName(null, session);

--- a/src/test/java/sh/jmx/jmxsh/boot/CliMainTest.java
+++ b/src/test/java/sh/jmx/jmxsh/boot/CliMainTest.java
@@ -1,15 +1,155 @@
 package sh.jmx.jmxsh.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import sh.jmx.jmxsh.cc.CommandCenter;
+import sh.jmx.jmxsh.io.CommandInput;
+import sh.jmx.jmxsh.io.CommandOutput;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.UserInterruptException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class CliMainTest {
+
+  @Mock
+  private CommandInput input;
+  @Mock
+  private CommandOutput output;
+  @Mock
+  private CommandCenter commandCenter;
+
+  @Test
+  void should_print_bye_when_interactive_input_is_interrupted() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    when(input.readLine()).thenThrow(new UserInterruptException(""));
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+    verify(output).printMessage("Welcome to jmx.sh, type \"help\" for available commands.");
+    verify(output).printMessage("Bye.");
+  }
+
+  @Test
+  void should_print_bye_when_interactive_input_reaches_end_of_file() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    when(input.readLine()).thenThrow(new EndOfFileException());
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+    verify(output).printMessage("Bye.");
+  }
+
+  @Test
+  void should_print_no_messages_when_non_interactive() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    options.setNonInteractive(true);
+    when(input.readLine()).thenThrow(new EndOfFileException());
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+    verify(output, never()).printMessage(anyString());
+  }
+
+  @Test
+  void should_print_no_messages_when_quiet() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    options.setQuiet(true);
+    when(input.readLine()).thenReturn(null);
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+    verify(output, never()).printMessage(anyString());
+  }
+
+  @Test
+  void should_not_print_bye_when_input_is_exhausted() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    when(input.readLine()).thenReturn("open localhost:9999", (String) null);
+    when(commandCenter.execute("open localhost:9999")).thenReturn(true);
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+    verify(output, never()).printMessage("Bye.");
+  }
+
+  @Test
+  void should_return_negative_line_number_when_command_fails_with_exit_on_failure() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    options.setExitOnFailure(true);
+    when(input.readLine()).thenReturn("first", "second");
+    when(commandCenter.execute("first")).thenReturn(true);
+    when(commandCenter.execute("second")).thenReturn(false);
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isEqualTo(-2);
+  }
+
+  @Test
+  void should_continue_when_command_fails_without_exit_on_failure() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    when(input.readLine()).thenReturn("bad command", (String) null);
+    when(commandCenter.execute("bad command")).thenReturn(false);
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+  }
+
+  @Test
+  void should_stop_reading_when_command_center_is_closed() throws IOException {
+    // Given
+    CliMainOptions options = new CliMainOptions();
+    when(input.readLine()).thenReturn("quit");
+    when(commandCenter.execute("quit")).thenReturn(true);
+    when(commandCenter.isClosed()).thenReturn(true);
+
+    // When
+    int exitCode = CliMain.runCommandLoop(input, output, commandCenter, options);
+
+    // Then
+    assertThat(exitCode).isZero();
+    verify(commandCenter).execute("quit");
+  }
 
   @Test
   void migrateHistoryCopiesLegacyFileWhenTargetMissing(@TempDir Path tmp) throws IOException {

--- a/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
@@ -64,7 +64,7 @@ class AliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer).hasToString("no aliases defined");
+    assertThat(writer).hasToString("No aliases defined.");
   }
 
   @Test
@@ -118,7 +118,7 @@ class AliasCommandTest {
 
     // Then
     verify(aliasStore).put("my_server", "myserver:1234");
-    assertThat(writer).hasToString("Alias my_server is set to myserver:1234");
+    assertThat(writer).hasToString("Alias my_server is set to myserver:1234.");
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/cmd/DomainCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/DomainCommandTest.java
@@ -143,6 +143,24 @@ class DomainCommandTest {
   }
 
   @Test
+  void should_unset_domain_when_null_literal_is_given() throws Exception {
+    // Given
+    DomainCommand unit = new DomainCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    when(session.getConnection()).thenReturn(connection);
+    unit.setDomain("null");
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    verify(session).unsetDomain();
+    assertThat(messageWriter.toString()).contains("Domain is unset.");
+  }
+
+  @Test
   void getDomainNameThrowsWhenSessionNull() {
     assertThatThrownBy(() -> DomainCommand.getDomainName("x", null))
         .isInstanceOf(NullPointerException.class);

--- a/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
@@ -115,6 +115,32 @@ class GetCommandTest {
     }
   }
 
+  @Test
+  void should_print_message_when_attribute_is_not_readable() throws Exception {
+    // Given
+    GetCommand unit = new GetCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    unit.setDomain("a");
+    unit.setBean("type=x");
+    unit.setAttributes(List.of("a"));
+    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
+    MBeanAttributeInfo attributeInfo = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    when(con.getDomains()).thenReturn(new String[] {"a"});
+    when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
+    when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
+    when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[] {attributeInfo});
+    when(attributeInfo.getName()).thenReturn("a");
+    when(attributeInfo.isReadable()).thenReturn(false);
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("Attribute a is not readable.");
+  }
+
   /** Test normal execution */
   @Test
   void executeNormally() {

--- a/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/GetCommandTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -82,8 +83,8 @@ class GetCommandTest {
 
     String[] attributePath = attribute.split("\\.");
 
-    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
-    MBeanAttributeInfo attributeInfo = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    MBeanAttributeInfo attributeInfo = mock(MBeanAttributeInfo.class);
     try {
       when(con.getDomains())
           .thenReturn(new String[] {domain, randomAlphabetic(5)});
@@ -124,8 +125,8 @@ class GetCommandTest {
     unit.setDomain("a");
     unit.setBean("type=x");
     unit.setAttributes(List.of("a"));
-    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
-    MBeanAttributeInfo attributeInfo = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    MBeanAttributeInfo attributeInfo = mock(MBeanAttributeInfo.class);
     when(con.getDomains()).thenReturn(new String[] {"a"});
     when(con.isRegistered(new ObjectName("a:type=x"))).thenReturn(true);
     when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
@@ -167,7 +168,7 @@ class GetCommandTest {
   void executeWithStrangeAttributeName() throws Exception {
     Map<String, Object> entries = new HashMap<>();
     entries.put("d", "bingo");
-    CompositeType compositeType = org.mockito.Mockito.mock(CompositeType.class);
+    CompositeType compositeType = mock(CompositeType.class);
     when(compositeType.keySet()).thenReturn(entries.keySet());
     doReturn(SimpleType.STRING).when(compositeType).getType("d");
     Object expectedValue = new CompositeDataSupport(compositeType, entries);
@@ -195,9 +196,9 @@ class GetCommandTest {
   @Test
   void fetchesMultipleAttributesInSingleBulkCall() throws Exception {
     ObjectName name = new ObjectName("a:type=x");
-    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
-    MBeanAttributeInfo attr1 = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
-    MBeanAttributeInfo attr2 = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    MBeanAttributeInfo attr1 = mock(MBeanAttributeInfo.class);
+    MBeanAttributeInfo attr2 = mock(MBeanAttributeInfo.class);
     when(con.getDomains()).thenReturn(new String[] {"a"});
     when(con.isRegistered(name)).thenReturn(true);
     when(con.getMBeanInfo(name)).thenReturn(beanInfo);
@@ -228,8 +229,8 @@ class GetCommandTest {
     StringWriter messageWriter = new StringWriter();
     when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, messageWriter));
     ObjectName name = new ObjectName("a:type=x");
-    MBeanInfo beanInfo = org.mockito.Mockito.mock(MBeanInfo.class);
-    MBeanAttributeInfo attributeInfo = org.mockito.Mockito.mock(MBeanAttributeInfo.class);
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    MBeanAttributeInfo attributeInfo = mock(MBeanAttributeInfo.class);
     when(con.getDomains()).thenReturn(new String[] {"a"});
     when(con.isRegistered(name)).thenReturn(true);
     when(con.getMBeanInfo(name)).thenReturn(beanInfo);

--- a/src/test/java/sh/jmx/jmxsh/cmd/InfoCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/InfoCommandTest.java
@@ -157,6 +157,92 @@ class InfoCommandTest {
     assertThat(writer.toString().trim()).isEqualTo("# operations");
   }
 
+  @Test
+  void should_print_message_when_bean_has_no_attributes() throws Exception {
+    // Given
+    InfoCommand unit = new InfoCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    unit.setBean("a:type=x");
+    unit.setType("a");
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
+    when(beanInfo.getClassName()).thenReturn("bogus class");
+    when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[0]);
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("There are no attributes.");
+  }
+
+  @Test
+  void should_print_message_when_bean_has_no_operations() throws Exception {
+    // Given
+    InfoCommand unit = new InfoCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    unit.setBean("a:type=x");
+    unit.setType("o");
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
+    when(beanInfo.getClassName()).thenReturn("bogus class");
+    when(beanInfo.getOperations()).thenReturn(new MBeanOperationInfo[0]);
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("There are no operations.");
+  }
+
+  @Test
+  void should_print_message_when_requested_operation_has_no_candidates() throws Exception {
+    // Given
+    InfoCommand unit = new InfoCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    unit.setBean("a:type=x");
+    unit.setOperation("x");
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
+    when(beanInfo.getClassName()).thenReturn("bogus class");
+    when(beanInfo.getOperations()).thenReturn(new MBeanOperationInfo[0]);
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("There are no operations.");
+  }
+
+  @Test
+  void should_print_bean_description_when_detail_option_is_set() throws Exception {
+    // Given
+    InfoCommand unit = new InfoCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    unit.setBean("a:type=x");
+    unit.setType("a");
+    unit.setShowDescription(true);
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
+    when(beanInfo.getClassName()).thenReturn("bogus class");
+    when(beanInfo.getDescription()).thenReturn("My bean description");
+    when(beanInfo.getAttributes()).thenReturn(new MBeanAttributeInfo[0]);
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("Description: My bean description");
+  }
+
   /**
    * Test execution and show available options
    *

--- a/src/test/java/sh/jmx/jmxsh/cmd/OpenCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/OpenCommandTest.java
@@ -69,6 +69,22 @@ class OpenCommandTest {
   }
 
   @Test
+  void should_print_not_connected_when_session_has_no_connection() throws Exception {
+    // Given
+    OpenCommand unit = new OpenCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    when(session.getConnection()).thenReturn(null);
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("Not connected.");
+  }
+
+  @Test
   void should_connect_to_resolved_target_when_url_is_alias() throws Exception {
     // Given
     StringWriter messageWriter = new StringWriter();

--- a/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/RunCommandTest.java
@@ -106,6 +106,32 @@ class RunCommandTest {
   }
 
   @Test
+  void should_print_invocation_latency_when_measure_is_enabled() throws Exception {
+    // Given
+    RunCommand unit = new RunCommand();
+    StringWriter messageWriter = new StringWriter();
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(messageWriter));
+    unit.setBean("a:type=x");
+    unit.setMeasure(true);
+    unit.setParameters(List.of("exe"));
+    MBeanInfo beanInfo = mock(MBeanInfo.class);
+    MBeanOperationInfo opInfo = mock(MBeanOperationInfo.class);
+    when(con.getMBeanInfo(new ObjectName("a:type=x"))).thenReturn(beanInfo);
+    when(beanInfo.getOperations()).thenReturn(new MBeanOperationInfo[] {opInfo});
+    when(opInfo.getName()).thenReturn("exe");
+    when(opInfo.getSignature()).thenReturn(new MBeanParameterInfo[0]);
+    when(con.invoke(new ObjectName("a:type=x"), "exe", new Object[0], new String[0]))
+        .thenReturn("bingo");
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    assertThat(messageWriter.toString()).contains("Invocation took").contains("ms.");
+  }
+
+  @Test
   void suggestArgumentWithNoBean() {
     command.setSession(session);
     assertThat(command.suggestArgument(null)).isEmpty();

--- a/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
@@ -40,7 +40,7 @@ class UnaliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer).hasToString("Alias my_server is removed");
+    assertThat(writer).hasToString("Alias my_server is removed.");
   }
 
   @Test


### PR DESCRIPTION
## Summary

### Quit message consistency
- Ctrl+C previously printed "Interrupted." while Ctrl+D fell through to the fatal-error handler with an uncaught `org.jline.reader.EndOfFileException` printed to the user.
- Both keys now go through the same catch clause in the read loop and print "Bye.", matching the `quit`/`exit`/`bye` command. The message is suppressed in quiet and non-interactive modes, like the welcome message.

### Sentence-style messages everywhere
- Every console message now starts with a capital letter and ends with a dot (e.g. "Not connected.", "Disconnected.", "Subscribed to X.", "Invocation took 12ms.").
- Two deliberate exceptions: list headers keep their trailing colon ("The following domains are available:") and key-value label lines are capitalized without a trailing dot ("MBean = java.lang:type=Memory") so the dot cannot be read as part of the value.
- Grammar fix: "there's no operations" → "There are no operations." (and attributes/notifications variants).
- Typo fixes: "candate" → "candidate" (beans error) and "sepcified"/"specificed" → "specified" (watch error).
- Sample transcripts in the README, website page and architecture doc updated to match.

### Testability refactor
- The read-execute loop is extracted from `CliMain.execute` into a package-private `runCommandLoop` method (same pattern as `migrateHistory`) so the quit, exit-on-failure and non-interactive behaviors are unit-testable.
- 16 new tests cover the loop and the message-printing branches of the info, get, open, run and domain commands.

## Test plan
- [x] Full suite passes: 291 unit + 68 integration/e2e tests
- [x] Manually verified with the uber-jar: interactive EOF prints "Bye." and exits 0, `quit` prints "Bye.", non-interactive EOF prints nothing
- [x] SonarCloud quality gate passes with 0 new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)