### PR TITLE
fix: handle lost JMX connections with a friendly message instead of raw exceptions

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/Connection.java
+++ b/src/main/java/sh/jmx/jmxsh/Connection.java
@@ -19,6 +19,14 @@ public record Connection(JMXConnector connector, JMXServiceURL url) {
     return connector.getConnectionId();
   }
 
+  public String getDisplayName() {
+    String host = url.getHost();
+    if (host != null && !host.isBlank()) {
+      return "%s:%d".formatted(host, url.getPort());
+    }
+    return url.toString();
+  }
+
   public MBeanServerConnection getServerConnection() throws IOException {
     return connector.getMBeanServerConnection();
   }

--- a/src/main/java/sh/jmx/jmxsh/Session.java
+++ b/src/main/java/sh/jmx/jmxsh/Session.java
@@ -1,7 +1,6 @@
 package sh.jmx.jmxsh;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Map;
 
 import javax.management.remote.JMXConnector;
@@ -50,11 +49,7 @@ public class Session {
     if (closed) {
       return;
     }
-    try {
-      disconnect();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    disconnect();
     closed = true;
   }
 
@@ -68,15 +63,18 @@ public class Session {
     log.info("connected to {}", url);
   }
 
-  public void disconnect() throws IOException {
+  public void disconnect() {
     if (connection == null) {
       return;
     }
     log.info("disconnecting from JMX server");
     try {
       connection.close();
+    } catch (IOException e) {
+      log.warn("failed to close JMX connection", e);
     } finally {
       connection = null;
+      unsetDomain();
     }
   }
 

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -170,7 +170,7 @@ public class CommandCenter {
     try {
       session.getConnection().getServerConnection().getDefaultDomain();
       return false;
-    } catch (IOException probeFailure) {
+    } catch (IOException _) {
       return true;
     }
   }

--- a/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
+++ b/src/main/java/sh/jmx/jmxsh/cc/CommandCenter.java
@@ -150,9 +150,38 @@ public class CommandCenter {
       doExecute(command);
       return true;
     } catch (JMException | RuntimeException e) {
+      if (isConnectionLost(e)) {
+        log.error("connection to JMX server lost", e);
+        session.getOutput().printMessage(
+            "Connection to %s was lost. Disconnected."
+                .formatted(session.getConnection().getDisplayName()));
+        session.disconnect();
+        return false;
+      }
       session.getOutput().printError(e);
       return false;
     }
+  }
+
+  private boolean isConnectionLost(Throwable e) {
+    if (!session.isConnected() || !hasIOExceptionCause(e)) {
+      return false;
+    }
+    try {
+      session.getConnection().getServerConnection().getDefaultDomain();
+      return false;
+    } catch (IOException probeFailure) {
+      return true;
+    }
+  }
+
+  private static boolean hasIOExceptionCause(Throwable e) {
+    for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+      if (cause instanceof IOException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public Set<String> getCommandNames() {

--- a/src/main/java/sh/jmx/jmxsh/cmd/QuitCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/QuitCommand.java
@@ -1,6 +1,5 @@
 package sh.jmx.jmxsh.cmd;
 
-import java.io.IOException;
 import sh.jmx.jmxsh.Command;
 import sh.jmx.jmxsh.Session;
 
@@ -9,9 +8,8 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "quit", aliases = {"exit", "bye"}, description = "Terminate console and exit")
 public class QuitCommand extends Command {
   @Override
-  public void execute() throws IOException {
+  public void execute() {
     Session session = getSession();
-    session.disconnect();
     session.close();
     session.getOutput().printMessage("Bye.");
   }

--- a/src/main/java/sh/jmx/jmxsh/utils/PromptTemplate.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/PromptTemplate.java
@@ -1,7 +1,5 @@
 package sh.jmx.jmxsh.utils;
 
-import javax.management.remote.JMXServiceURL;
-
 import sh.jmx.jmxsh.Session;
 
 /**
@@ -121,11 +119,6 @@ public final class PromptTemplate {
     if (!session.isConnected()) {
       return "";
     }
-    JMXServiceURL url = session.getConnection().url();
-    String host = url.getHost();
-    if (host != null && !host.isBlank()) {
-      return host + ":" + url.getPort();
-    }
-    return url.toString();
+    return session.getConnection().getDisplayName();
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/SessionTest.java
+++ b/src/test/java/sh/jmx/jmxsh/SessionTest.java
@@ -1,8 +1,12 @@
 package sh.jmx.jmxsh;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
 
@@ -72,6 +76,54 @@ class SessionTest {
   void connectThrowsWhenUrlNull() {
     assertThatThrownBy(() -> session.connect(null, null))
         .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void should_clear_connection_domain_and_bean_when_disconnected() throws Exception {
+    // Given
+    session.connect(JmxUrl.parse("localhost:9991").toServiceUrl(null), null);
+    session.setDomain("java.lang");
+    session.setBean("java.lang:type=Memory");
+
+    // When
+    session.disconnect();
+
+    // Then
+    assertThat(session.isConnected()).isFalse();
+    assertThat(session.getDomain()).isNull();
+    assertThat(session.getBean()).isNull();
+    verify(con).close();
+  }
+
+  @Test
+  void should_clear_state_and_not_throw_when_connector_close_fails() throws Exception {
+    // Given
+    session.connect(JmxUrl.parse("localhost:9991").toServiceUrl(null), null);
+    session.setDomain("java.lang");
+    session.setBean("java.lang:type=Memory");
+    doThrow(new IOException("Connection refused")).when(con).close();
+
+    // When
+    assertThatCode(session::disconnect).doesNotThrowAnyException();
+
+    // Then
+    assertThat(session.isConnected()).isFalse();
+    assertThat(session.getDomain()).isNull();
+    assertThat(session.getBean()).isNull();
+  }
+
+  @Test
+  void should_close_without_throwing_when_connector_close_fails() throws Exception {
+    // Given
+    session.connect(JmxUrl.parse("localhost:9991").toServiceUrl(null), null);
+    doThrow(new IOException("Connection refused")).when(con).close();
+
+    // When
+    assertThatCode(session::close).doesNotThrowAnyException();
+
+    // Then
+    assertThat(session.isClosed()).isTrue();
+    assertThat(session.isConnected()).isFalse();
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/cmd/QuitCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/QuitCommandTest.java
@@ -32,7 +32,6 @@ class QuitCommandTest {
     when(session.getOutput()).thenReturn(new WriterCommandOutput(new StringWriter(), null));
     command.setSession(session);
     command.execute();
-    verify(session).disconnect();
     verify(session).close();
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/QuitCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/QuitCommandTest.java
@@ -26,9 +26,8 @@ class QuitCommandTest {
     command = new QuitCommand();
   }
 
-  /** @throws Exception */
   @Test
-  void execute() throws Exception {
+  void execute() {
     when(session.getOutput()).thenReturn(new WriterCommandOutput(new StringWriter(), null));
     command.setSession(session);
     command.execute();

--- a/src/test/java/sh/jmx/jmxsh/integration/ConnectionLossIT.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/ConnectionLossIT.java
@@ -1,0 +1,66 @@
+package sh.jmx.jmxsh.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.StringWriter;
+
+import sh.jmx.jmxsh.cc.CommandCenter;
+import sh.jmx.jmxsh.io.WriterCommandOutput;
+import org.junit.jupiter.api.Test;
+
+/** Integration tests for behavior when the JMX server dies while a session is connected. */
+class ConnectionLossIT {
+
+  @Test
+  void should_print_friendly_message_and_clear_state_when_connection_is_lost() throws Exception {
+    // Given
+    EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+    jmxServer.start();
+    StringWriter resultWriter = new StringWriter();
+    StringWriter messageWriter = new StringWriter();
+    CommandCenter cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+    assertThat(cc.execute("open " + jmxServer.getConnectionUrl())).isTrue();
+    assertThat(cc.execute("domain test")).isTrue();
+    assertThat(cc.execute("bean test:type=TestMBean")).isTrue();
+    jmxServer.stop();
+
+    // When
+    boolean result = cc.execute("beans");
+
+    // Then
+    assertThat(result).isFalse();
+    assertThat(messageWriter.toString())
+        .contains("was lost. Disconnected.")
+        .doesNotContain("ConnectException")
+        .doesNotContain("nested exception");
+    assertThat(cc.getSession().isConnected()).isFalse();
+    assertThat(cc.getSession().getDomain()).isNull();
+    assertThat(cc.getSession().getBean()).isNull();
+    assertThatCode(cc::close).doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_quit_cleanly_when_connection_is_lost() throws Exception {
+    // Given
+    EmbeddedJmxServer jmxServer = new EmbeddedJmxServer();
+    jmxServer.start();
+    StringWriter resultWriter = new StringWriter();
+    StringWriter messageWriter = new StringWriter();
+    CommandCenter cc = new CommandCenter(new WriterCommandOutput(resultWriter, messageWriter), null);
+    assertThat(cc.execute("open " + jmxServer.getConnectionUrl())).isTrue();
+    jmxServer.stop();
+
+    // When
+    boolean result = cc.execute("quit");
+
+    // Then
+    assertThat(result).isTrue();
+    assertThat(cc.isClosed()).isTrue();
+    assertThat(messageWriter.toString())
+        .contains("Bye.")
+        .doesNotContain("ConnectException")
+        .doesNotContain("nested exception");
+    assertThatCode(cc::close).doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/sh/jmx/jmxsh/integration/EmbeddedJmxServer.java
+++ b/src/test/java/sh/jmx/jmxsh/integration/EmbeddedJmxServer.java
@@ -39,6 +39,10 @@ public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
+    start();
+  }
+
+  public void start() throws Exception {
     // Create RMI registry with retry to avoid TOCTOU race on port selection
     registry = createRegistryOnRandomPort();
 
@@ -75,14 +79,21 @@ public class EmbeddedJmxServer implements BeforeAllCallback, AfterAllCallback {
 
   @Override
   public void afterAll(ExtensionContext context) throws Exception {
+    stop();
+  }
+
+  public void stop() throws Exception {
     if (connectorServer != null) {
       connectorServer.stop();
+      connectorServer = null;
     }
     if (registry != null) {
       UnicastRemoteObject.unexportObject(registry, true);
+      registry = null;
     }
     if (mBeanServer != null) {
       MBeanServerFactory.releaseMBeanServer(mBeanServer);
+      mBeanServer = null;
     }
   }
 

--- a/src/test/java/sh/jmx/jmxsh/utils/PromptTemplateTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/PromptTemplateTest.java
@@ -21,9 +21,6 @@ class PromptTemplateTest {
   @Mock
   private Session session;
 
-  @Mock
-  private Connection connection;
-
   @Test
   void optionalBlockHiddenWhenAllVarsEmpty() {
     when(session.isConnected()).thenReturn(false);
@@ -33,16 +30,16 @@ class PromptTemplateTest {
   @Test
   void optionalBlockShownWhenVarNonEmpty() throws Exception {
     when(session.isConnected()).thenReturn(true);
-    when(session.getConnection()).thenReturn(connection);
-    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://srv:9010"));
+    when(session.getConnection())
+        .thenReturn(new Connection(null, new JMXServiceURL("service:jmx:jmxmp://srv:9010")));
     assertThat(PromptTemplate.resolve("{?[{server}] }> ", session)).isEqualTo("[srv:9010] > ");
   }
 
   @Test
   void optionalBlocksComposed() throws Exception {
     when(session.isConnected()).thenReturn(true);
-    when(session.getConnection()).thenReturn(connection);
-    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://srv:9010"));
+    when(session.getConnection())
+        .thenReturn(new Connection(null, new JMXServiceURL("service:jmx:jmxmp://srv:9010")));
     when(session.getDomain()).thenReturn("java.lang");
     when(session.getBean()).thenReturn("java.lang:type=Memory");
     assertThat(PromptTemplate.resolve("{?[{server}] }{?{domain}}{?/{bean}}> ", session))
@@ -87,17 +84,16 @@ class PromptTemplateTest {
   @Test
   void serverVariableHostPort() throws Exception {
     when(session.isConnected()).thenReturn(true);
-    when(session.getConnection()).thenReturn(connection);
-    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://myhost:1234"));
+    when(session.getConnection())
+        .thenReturn(new Connection(null, new JMXServiceURL("service:jmx:jmxmp://myhost:1234")));
     assertThat(PromptTemplate.resolve("[{server}]> ", session)).isEqualTo("[myhost:1234]> ");
   }
 
   @Test
   void serverVariableFallsBackToFullUrlWhenNoHost() throws Exception {
     when(session.isConnected()).thenReturn(true);
-    when(session.getConnection()).thenReturn(connection);
     JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:9010/jmxrmi");
-    when(connection.url()).thenReturn(url);
+    when(session.getConnection()).thenReturn(new Connection(null, url));
     assertThat(PromptTemplate.resolve("[{server}]> ", session))
         .isEqualTo("[" + url.toString() + "]> ");
   }
@@ -129,8 +125,8 @@ class PromptTemplateTest {
   @Test
   void allVariablesResolved() throws Exception {
     when(session.isConnected()).thenReturn(true);
-    when(session.getConnection()).thenReturn(connection);
-    when(connection.url()).thenReturn(new JMXServiceURL("service:jmx:jmxmp://srv:5000"));
+    when(session.getConnection())
+        .thenReturn(new Connection(null, new JMXServiceURL("service:jmx:jmxmp://srv:5000")));
     when(session.getDomain()).thenReturn("java.lang");
     when(session.getBean()).thenReturn("type=Memory");
     assertThat(PromptTemplate.resolve("[{server} {domain}/{bean}]> ", session))


### PR DESCRIPTION
## Problem

When connected to a JMX process that dies (killed local PID, or a remote server reboot), jmxsh misbehaved in two ways:

1. Commands like `beans` failed with an unfriendly error and left the session broken: the dead connection was kept, `domain`/`bean` stayed set, and the prompt kept showing the stale `[host:port]`.
2. Quitting afterwards (Ctrl+C, Ctrl+D or `quit`) printed raw RMI exception text to the console and exited with code 1:

   ```
   java.rmi.ConnectException: Connection refused to host: 127.0.0.1; nested exception is:
           java.net.ConnectException: Connection refused
   ```

   Closing the dead connector threw `java.rmi.ConnectException`, which `Session.close()` wrapped in `UncheckedIOException` and escaped to the fatal error handler in `CliMain`.

## Changes

- **`Session.disconnect()` never throws and clears all state.** A failing `connector.close()` is logged (file appender only) and swallowed; the connection, domain and bean are always cleared. This also fixes `close`/`quit` leaving stale domain/bean behind, and lets `Session.close()` drop its `UncheckedIOException` wrapping.
- **Connection-loss detection in `CommandCenter.execute`.** When a command fails with an `IOException` in its cause chain while connected, a cheap liveness probe (`getDefaultDomain()`) decides whether the connection is dead. If so, the full exception goes to the log, the user sees `Connection to <server> was lost. Disconnected.`, the session state is cleared and the prompt falls back to `> `. A live connection passes the probe and keeps the existing error behavior.
- **`Connection.getDisplayName()`** centralizes the server display logic (host:port, or the full service URL when the URL carries no host), reused by both `PromptTemplate` and the new lost-connection message.
- **`QuitCommand`** drops its redundant `disconnect()` call (`close()` already disconnects).

Raw exception text never reaches the console on these paths anymore; full stack traces are written to the log file only when `logging.file.enabled=true` (existing Logback setup, unchanged).

## Notes for reviewers

- New `ConnectionLossIT` kills the embedded JMX server mid-session via a new idempotent `stop()` on `EmbeddedJmxServer`; `SessionTest` covers the disconnect/close behavior on a failing connector.
- `PromptTemplateTest` now uses real `Connection` records instead of mocking one, so the shared `getDisplayName()` logic is exercised for real.
- `WatchCommand`'s background poller still prints its own raw-ish `IOException` message if the server dies mid-watch; handling that needs watch-task cancellation and is left as a follow-up.
- Verified end-to-end against a real killed process: friendly message, cleared state, `Bye.`, exit code 0, and full `ConnectException` traces in `jmxsh.log` when file logging is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)