### PR TITLE
fix: distinct message when closing with no open connection

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/cmd/CloseCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/CloseCommand.java
@@ -11,6 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 public class CloseCommand extends Command {
   @Override
   public void execute() throws IOException {
+    if (!getSession().isConnected()) {
+      getSession().getOutput().printMessage("Not connected.");
+      return;
+    }
     log.info("closing JMX connection");
     getSession().disconnect();
     getSession().getOutput().printMessage("Disconnected.");

--- a/src/test/java/sh/jmx/jmxsh/cmd/CloseCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/CloseCommandTest.java
@@ -1,16 +1,20 @@
 package sh.jmx.jmxsh.cmd;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.StringWriter;
 
-import sh.jmx.jmxsh.Session;
-import sh.jmx.jmxsh.io.WriterCommandOutput;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import sh.jmx.jmxsh.Session;
+import sh.jmx.jmxsh.io.WriterCommandOutput;
 
 /**
  * Test of {@link CloseCommand}
@@ -18,28 +22,41 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 @ExtendWith(MockitoExtension.class)
 class CloseCommandTest {
+
   @Mock
   private Session session;
 
-  private CloseCommand command;
+  @Test
+  void should_disconnect_and_report_when_connected() throws IOException {
+    // Given
+    StringWriter writer = new StringWriter();
+    when(session.isConnected()).thenReturn(true);
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    CloseCommand unit = new CloseCommand();
+    unit.setSession(session);
 
-  /** Set up classes to test */
-  @BeforeEach
-  void setUp() {
-    command = new CloseCommand();
+    // When
+    unit.execute();
+
+    // Then
+    verify(session).disconnect();
+    assertThat(writer).hasToString("Disconnected.");
   }
 
-  /**
-   * Test execution
-   *
-   * @throws Exception
-   */
   @Test
-  void execute() throws Exception {
+  void should_report_not_connected_and_skip_disconnect_when_not_connected() throws IOException {
+    // Given
     StringWriter writer = new StringWriter();
-    org.mockito.Mockito.when(session.getOutput()).thenReturn(new WriterCommandOutput(writer, null));
-    command.setSession(session);
-    command.execute();
-    verify(session).disconnect();
+    when(session.isConnected()).thenReturn(false);
+    when(session.getOutput()).thenReturn(new WriterCommandOutput(writer));
+    CloseCommand unit = new CloseCommand();
+    unit.setSession(session);
+
+    // When
+    unit.execute();
+
+    // Then
+    verify(session, never()).disconnect();
+    assertThat(writer).hasToString("Not connected.");
   }
 }


### PR DESCRIPTION
## What changed

The `close` command previously always printed `Disconnected.`, even when no JMX connection was open. It now checks the session state first:

- **No open connection** → prints `Not connected.` and skips the disconnect (matching the wording already used by the `open` command).
- **Connection open** → disconnects and prints `Disconnected.` as before.

## Why

Printing `Disconnected.` when nothing was connected was misleading. Reusing the existing `Not connected.` phrasing keeps console messaging consistent across commands.

## Notes for reviewers

- `CloseCommandTest` was rewritten to cover both branches. The old test only verified `disconnect()`, which would now fail since a mock session reports "not connected" by default. Tests follow the project's Java conventions (AssertJ, `unit` naming, `should_..._when_...`).
- The existing `testCloseWithoutOpen` integration test still passes — the command remains a successful no-op when nothing is connected.
- Full build green: 295 unit tests + 70 IT/E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)