### PR TITLE
docs: add README table of contents and fix erroneous "#" in message examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ invoke operations — all from the comfort of your terminal.
 > [LeMyst/jmxterm](https://github.com/LeMyst/jmxterm). The goal is to keep the project alive with
 > regular updates and releases, dependency maintenance, and new features.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Features](#features)
+- [Usage](#usage)
+  - [Key Commands](#key-commands)
+  - [JMXMP Connections](#jmxmp-connections)
+  - [Connection Aliases](#connection-aliases)
+  - [Watching Attributes](#watching-attributes)
+  - [Configuration](#configuration)
+  - [Non-Interactive Mode](#non-interactive-mode)
+- [Documentation](#documentation)
+- [License](#license)
+
 ## Installation
 
 ### JAR (all platforms)
@@ -123,7 +137,7 @@ To connect using the JMXMP protocol instead of the default RMI:
 
 ```
 $> open jmxmp://localhost:9999
-#Connection to jmxmp://localhost:9999 is opened.
+Connection to jmxmp://localhost:9999 is opened.
 ```
 
 Full service URLs are also supported: `open service:jmx:jmxmp://localhost:9999`
@@ -135,9 +149,9 @@ accepts: a `host:port`, a PID, a `jmxmp://` address or a full JMX service URL.
 
 ```
 $> alias my_server myserver:1234
-#Alias my_server is set to myserver:1234.
+Alias my_server is set to myserver:1234.
 $> open my_server
-#Connection to my_server (myserver:1234) is opened.
+Connection to my_server (myserver:1234) is opened.
 ```
 
 Aliases also work with the `-l` command line option:


### PR DESCRIPTION
## What changed

- **Added a Table of Contents** to the README, linking the main sections (Installation, Features, Usage) and the Usage subsections for easier navigation.
- **Fixed three usage examples** that incorrectly prefixed console messages with a leading `#`:
  - `#Connection to jmxmp://localhost:9999 is opened.` → `Connection to jmxmp://localhost:9999 is opened.`
  - `#Alias my_server is set to myserver:1234.` → `Alias my_server is set to myserver:1234.`
  - `#Connection to my_server (myserver:1234) is opened.` → `Connection to my_server (myserver:1234) is opened.`

## Why

The `#` prefix never appears in real program output. The output layer (`PrintStreamCommandOutput.printMessage`) prints messages verbatim, and `AliasCommandTest` asserts the exact string `Alias my_server is set to myserver:1234.` with no prefix. The examples now match actual output.

## Reviewer notes

- Docs-only change; no code touched.
- The other usage block in the README already showed messages correctly without `#`, so only the three examples above were affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)