### PR TITLE
refactor: replace var with explicit types

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
+++ b/src/main/java/sh/jmx/jmxsh/cmd/WatchCommand.java
@@ -181,7 +181,7 @@ public class WatchCommand extends Command {
     Map<String, Object> fetchedValues = fetchValues(beanName, connection);
     String result;
     if (outputFormat == null) {
-      var sb = new StringBuilder();
+      StringBuilder sb = new StringBuilder();
       boolean first = true;
       for (String attributeName : attributes) {
         if (first) {

--- a/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/FileCommandOutput.java
@@ -10,15 +10,15 @@ import java.nio.file.StandardOpenOption;
 import lombok.NonNull;
 
 public class FileCommandOutput implements CommandOutput {
-  private final PrintWriter fileWriter;
 
+  private final PrintWriter fileWriter;
   private final WriterCommandOutput output;
 
   public FileCommandOutput(@NonNull Path file, boolean appendToOutput) throws IOException {
     Path af = file.toAbsolutePath();
     Files.createDirectories(af.getParent());
 
-    var openOptions = appendToOutput
+    StandardOpenOption[] openOptions = appendToOutput
         ? new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.APPEND}
         : new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING};
     fileWriter = new PrintWriter(

--- a/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
@@ -5,17 +5,9 @@ import java.io.PrintStream;
 import lombok.NonNull;
 
 public class PrintStreamCommandOutput implements CommandOutput {
+
   private final PrintStream messageOutput;
-
   private final PrintStream resultOutput;
-
-  public PrintStreamCommandOutput() {
-    this(System.out);
-  }
-
-  public PrintStreamCommandOutput(PrintStream output) {
-    this(output, System.err);
-  }
 
   public PrintStreamCommandOutput(@NonNull PrintStream resultOutput, @NonNull PrintStream messageOutput) {
     this.resultOutput = resultOutput;

--- a/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
@@ -6,8 +6,8 @@ import java.io.Writer;
 import lombok.NonNull;
 
 public class WriterCommandOutput implements CommandOutput {
-  private final Writer messageOutput;
 
+  private final Writer messageOutput;
   private final Writer resultOutput;
 
   public WriterCommandOutput(Writer output) {

--- a/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
+++ b/src/main/java/sh/jmx/jmxsh/utils/ValueFormat.java
@@ -40,7 +40,7 @@ public final class ValueFormat {
     if (!input.contains("\\u")) {
       return input;
     }
-    var sb = new StringBuilder(input.length());
+    StringBuilder sb = new StringBuilder(input.length());
     int i = 0;
     while (i < input.length()) {
       char ch = input.charAt(i);

--- a/src/test/java/sh/jmx/jmxsh/boot/LoggingConfiguratorTest.java
+++ b/src/test/java/sh/jmx/jmxsh/boot/LoggingConfiguratorTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
+import java.util.Iterator;
 
 import sh.jmx.jmxsh.utils.AppConfig;
 import sh.jmx.jmxsh.utils.XdgDirectories;
@@ -18,6 +19,8 @@ import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 
 @ExtendWith(MockitoExtension.class)
 class LoggingConfiguratorTest {
@@ -76,7 +79,7 @@ class LoggingConfiguratorTest {
 
     // iteratorForAppenders() returns a single element; we verify no duplicate by
     // checking that exactly one appender named FILE exists.
-    var appenders = root.iteratorForAppenders();
+    Iterator<Appender<ILoggingEvent>> appenders = root.iteratorForAppenders();
     int count = 0;
     while (appenders.hasNext()) {
       if ("FILE".equals(appenders.next().getName())) {

--- a/src/test/java/sh/jmx/jmxsh/e2e/JmxshProcessHelper.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/JmxshProcessHelper.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 /**
  * Launches the jmxsh uber JAR as a subprocess in non-interactive mode and provides methods to
@@ -132,7 +133,7 @@ public class JmxshProcessHelper implements AutoCloseable {
 
   private static Path findUberJar() throws IOException {
     Path targetDir = Path.of("target");
-    try (var files = Files.list(targetDir)) {
+    try (Stream<Path> files = Files.list(targetDir)) {
       return files
           .filter(p -> p.getFileName().toString().matches("jmxsh-.*-uber\\.jar"))
           .findFirst()

--- a/src/test/java/sh/jmx/jmxsh/e2e/TestTargetApp.java
+++ b/src/test/java/sh/jmx/jmxsh/e2e/TestTargetApp.java
@@ -65,7 +65,7 @@ public class TestTargetApp {
     }
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main() throws Exception {
     MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
     mbs.registerMBean(
         new StandardMBean(new TestMBeanImpl(), TestMBean.class),

--- a/src/test/java/sh/jmx/jmxsh/utils/XdgDirectoriesTest.java
+++ b/src/test/java/sh/jmx/jmxsh/utils/XdgDirectoriesTest.java
@@ -10,88 +10,88 @@ class XdgDirectoriesTest {
 
   @Test
   void stateHomeUsesEnvVarWhenSet() {
-    var dirs = new XdgDirectories(_ -> "/custom/state", "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> "/custom/state", "/home/testuser");
     assertThat(dirs.getStateHome()).isEqualTo(Path.of("/custom/state"));
   }
 
   @Test
   void stateHomeFallsBackWhenEnvVarIsNull() {
-    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> null, "/home/testuser");
     assertThat(dirs.getStateHome()).isEqualTo(Path.of("/home/testuser/.local/state"));
   }
 
   @Test
   void stateHomeFallsBackWhenEnvVarIsBlank() {
-    var dirs = new XdgDirectories(_ -> "  ", "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> "  ", "/home/testuser");
     assertThat(dirs.getStateHome()).isEqualTo(Path.of("/home/testuser/.local/state"));
   }
 
   @Test
   void historyFileResolvesUnderStateHome() {
-    var dirs = new XdgDirectories(_ -> "/xdg/state", "/ignored");
+    XdgDirectories dirs = new XdgDirectories(_ -> "/xdg/state", "/ignored");
     assertThat(dirs.getHistoryFile()).isEqualTo(Path.of("/xdg/state/jmxsh/history"));
   }
 
   @Test
   void historyFileUsesDefaultStateHome() {
-    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> null, "/home/testuser");
     assertThat(dirs.getHistoryFile())
         .isEqualTo(Path.of("/home/testuser/.local/state/jmxsh/history"));
   }
 
   @Test
   void configHomeUsesEnvVarWhenSet() {
-    var dirs = new XdgDirectories(_ -> "/custom/config", "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> "/custom/config", "/home/testuser");
     assertThat(dirs.getConfigHome()).isEqualTo(Path.of("/custom/config"));
   }
 
   @Test
   void configHomeFallsBackToDefaultWhenEnvVarIsNull() {
-    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> null, "/home/testuser");
     assertThat(dirs.getConfigHome()).isEqualTo(Path.of("/home/testuser/.config"));
   }
 
   @Test
   void configHomeFallsBackToDefaultWhenEnvVarIsBlank() {
-    var dirs = new XdgDirectories(_ -> "  ", "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> "  ", "/home/testuser");
     assertThat(dirs.getConfigHome()).isEqualTo(Path.of("/home/testuser/.config"));
   }
 
   @Test
   void configFileResolvesUnderConfigHome() {
-    var dirs = new XdgDirectories(k -> k.equals("XDG_CONFIG_HOME") ? "/xdg/config" : null, "/ignored");
+    XdgDirectories dirs = new XdgDirectories(k -> k.equals("XDG_CONFIG_HOME") ? "/xdg/config" : null, "/ignored");
     assertThat(dirs.getConfigFile()).isEqualTo(Path.of("/xdg/config/jmxsh/config.properties"));
   }
 
   @Test
   void configFileUsesDefaultConfigHome() {
-    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> null, "/home/testuser");
     assertThat(dirs.getConfigFile())
         .isEqualTo(Path.of("/home/testuser/.config/jmxsh/config.properties"));
   }
 
   @Test
   void aliasesFileResolvesUnderConfigHome() {
-    var dirs = new XdgDirectories(k -> k.equals("XDG_CONFIG_HOME") ? "/xdg/config" : null, "/ignored");
+    XdgDirectories dirs = new XdgDirectories(k -> k.equals("XDG_CONFIG_HOME") ? "/xdg/config" : null, "/ignored");
     assertThat(dirs.getAliasesFile()).isEqualTo(Path.of("/xdg/config/jmxsh/aliases.properties"));
   }
 
   @Test
   void aliasesFileUsesDefaultConfigHome() {
-    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> null, "/home/testuser");
     assertThat(dirs.getAliasesFile())
         .isEqualTo(Path.of("/home/testuser/.config/jmxsh/aliases.properties"));
   }
 
   @Test
   void logFileResolvesUnderStateHome() {
-    var dirs = new XdgDirectories(k -> k.equals("XDG_STATE_HOME") ? "/xdg/state" : null, "/ignored");
+    XdgDirectories dirs = new XdgDirectories(k -> k.equals("XDG_STATE_HOME") ? "/xdg/state" : null, "/ignored");
     assertThat(dirs.getLogFile()).isEqualTo(Path.of("/xdg/state/jmxsh/logs/jmxsh.log"));
   }
 
   @Test
   void logFileUsesDefaultStateHome() {
-    var dirs = new XdgDirectories(_ -> null, "/home/testuser");
+    XdgDirectories dirs = new XdgDirectories(_ -> null, "/home/testuser");
     assertThat(dirs.getLogFile())
         .isEqualTo(Path.of("/home/testuser/.local/state/jmxsh/logs/jmxsh.log"));
   }


### PR DESCRIPTION
## Summary
- Replace every use of the `var` keyword with the inferred explicit type across main and test sources.
- Also bundles minor pre-existing IO cleanups (per request):
  - `PrintStreamCommandOutput`: drop the two unused convenience constructors, reorder fields.
  - `WriterCommandOutput`: field reordering.
  - `TestTargetApp`: simplify the `main` signature to no-arg.

## var replacements
| File | Inferred type |
|------|---------------|
| `WatchCommand.java` | `StringBuilder` |
| `FileCommandOutput.java` | `StandardOpenOption[]` |
| `ValueFormat.java` | `StringBuilder` |
| `LoggingConfiguratorTest.java` | `Iterator<Appender<ILoggingEvent>>` |
| `XdgDirectoriesTest.java` (14×) | `XdgDirectories` |
| `JmxshProcessHelper.java` | `Stream<Path>` |

## Test plan
- `mvn clean verify` → BUILD SUCCESS, 70 tests pass (unit + integration + e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)