### PR TITLE
refactor: simplify CommandOutput and fix printMessage newline contract

### DIFF
--- a/src/main/java/sh/jmx/jmxsh/io/CommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/CommandOutput.java
@@ -16,7 +16,9 @@ public interface CommandOutput extends AutoCloseable {
   void print(String output);
 
   /** @param e Error to print out */
-  void printError(Throwable e);
+  default void printError(Throwable e) {
+    printMessage(e.getMessage() != null ? e.getMessage() : e.toString());
+  }
 
   /**
    * Print out value to output as standalone line

--- a/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/PrintStreamCommandOutput.java
@@ -20,12 +20,6 @@ public class PrintStreamCommandOutput implements CommandOutput {
   }
 
   @Override
-  public void printError(Throwable e) {
-    String message = e.getMessage() != null ? e.getMessage() : e.toString();
-    messageOutput.println(message);
-  }
-
-  @Override
   public void printMessage(String message) {
     messageOutput.println(message);
   }

--- a/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/VerboseCommandOutput.java
@@ -34,10 +34,7 @@ public class VerboseCommandOutput implements CommandOutput {
   @Override
   public void printError(Throwable e) {
     log.error("command execution error: {}", e.getMessage(), e);
-    if (modeSupplier.get() != OutputMode.SILENT) {
-      String message = e.getMessage() != null ? e.getMessage() : e.toString();
-      output.printMessage(message);
-    }
+    CommandOutput.super.printError(e);
   }
 
   @Override

--- a/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
+++ b/src/main/java/sh/jmx/jmxsh/io/WriterCommandOutput.java
@@ -24,29 +24,19 @@ public class WriterCommandOutput implements CommandOutput {
     if (output == null) {
       return;
     }
-    try {
-      resultOutput.write(output);
-    } catch (IOException e) {
-      throw new RuntimeIOException("Can't print out result", e);
-    }
-  }
-
-  @Override
-  public void printError(Throwable e) {
-    try {
-      String message = e.getMessage() != null ? e.getMessage() : e.toString();
-      messageOutput.write(message);
-    } catch (IOException ex) {
-      throw new RuntimeIOException("Can't print error message", ex);
-    }
+    write(resultOutput, output, "Can't print out result");
   }
 
   @Override
   public void printMessage(String message) {
+    write(messageOutput, String.format("%s%n", message), "Can't print out message");
+  }
+
+  private void write(Writer target, String text, String errorMessage) {
     try {
-      messageOutput.write(message);
+      target.write(text);
     } catch (IOException e) {
-      throw new RuntimeIOException("Can't print out message", e);
+      throw new RuntimeIOException(errorMessage, e);
     }
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/AliasCommandTest.java
@@ -64,7 +64,7 @@ class AliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer).hasToString("No aliases defined.");
+    assertThat(writer).hasToString("No aliases defined." + System.lineSeparator());
   }
 
   @Test
@@ -118,7 +118,7 @@ class AliasCommandTest {
 
     // Then
     verify(aliasStore).put("my_server", "myserver:1234");
-    assertThat(writer).hasToString("Alias my_server is set to myserver:1234.");
+    assertThat(writer).hasToString("Alias my_server is set to myserver:1234." + System.lineSeparator());
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/cmd/CloseCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/CloseCommandTest.java
@@ -40,7 +40,7 @@ class CloseCommandTest {
 
     // Then
     verify(session).disconnect();
-    assertThat(writer).hasToString("Disconnected.");
+    assertThat(writer).hasToString("Disconnected." + System.lineSeparator());
   }
 
   @Test
@@ -57,6 +57,6 @@ class CloseCommandTest {
 
     // Then
     verify(session, never()).disconnect();
-    assertThat(writer).hasToString("Not connected.");
+    assertThat(writer).hasToString("Not connected." + System.lineSeparator());
   }
 }

--- a/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
+++ b/src/test/java/sh/jmx/jmxsh/cmd/UnaliasCommandTest.java
@@ -40,7 +40,7 @@ class UnaliasCommandTest {
     unit.execute();
 
     // Then
-    assertThat(writer).hasToString("Alias my_server is removed.");
+    assertThat(writer).hasToString("Alias my_server is removed." + System.lineSeparator());
   }
 
   @Test

--- a/src/test/java/sh/jmx/jmxsh/io/WriterCommandOutputTest.java
+++ b/src/test/java/sh/jmx/jmxsh/io/WriterCommandOutputTest.java
@@ -24,4 +24,14 @@ class WriterCommandOutputTest {
     output.print("hello world");
     assertThat(writer).hasToString("hello world");
   }
+
+  @Test
+  void printMessageAppendsNewlineToMessageOutput() {
+    StringWriter result = new StringWriter();
+    StringWriter message = new StringWriter();
+    WriterCommandOutput output = new WriterCommandOutput(result, message);
+    output.printMessage("status");
+    assertThat(message).hasToString("status" + System.lineSeparator());
+    assertThat(result).hasToString("");
+  }
 }


### PR DESCRIPTION
## What

Simplifies the `CommandOutput` interface and its implementations, and fixes a documented-contract violation in `WriterCommandOutput.printMessage`.

### Simplification (removes duplication / dead code)
- **`printError` is now a `default` method** on `CommandOutput` that formats the throwable and routes it through `printMessage`. This is the single home for the `e.getMessage() != null ? e.getMessage() : e.toString()` fallback that was previously copied in three implementations.
- Dropped the now-redundant `printError` overrides in `PrintStreamCommandOutput` and `WriterCommandOutput` (inherited from the default). These were effectively dead: everything routes through `VerboseCommandOutput`, which recomputed the message and called `printMessage` anyway.
- `VerboseCommandOutput.printError` keeps only the logging concern and defers to `CommandOutput.super.printError(e)`, so the `SILENT` gate lives solely in `printMessage`.
- Folded `WriterCommandOutput`'s three identical `try/catch` blocks into one private `write(...)` helper.

### Bug fix (the one behavior change)
`CommandOutput.printMessage`'s javadoc says *"New line is always appended"*, but `WriterCommandOutput.printMessage` wrote the message with **no newline**. In file-output mode (`-o <file>`), messages/errors go to stderr via this path and ran together on one line. It now appends the line separator, matching `PrintStreamCommandOutput` (which already used `println`).

## Why
Judged against what this ~15-year-old JMX CLI actually needs — stdout/stderr output, file output, and a silent/brief mode gate — the design is sound, but the throwable-formatting logic was triplicated and the two leaf `printError` overrides were near-dead. The changes only *remove* code and fix a real contract violation; no new types or abstraction layers. Deliberately left out of scope as over-engineering: converting `FileCommandOutput` from composition to inheritance, aligning `print(null)` behavior, and renaming `VerboseCommandOutput`.

## Reviewer notes
- Net **−16 lines** in main source.
- 5 exact-string assertions in `CloseCommandTest`, `AliasCommandTest`, and `UnaliasCommandTest` were updated to expect the trailing `System.lineSeparator()`. They had been pinning the old test-double behavior that diverged from real stdout output (which already appended newlines). The existing `AliasCommandTest` `println` assertion already used this `+ System.lineSeparator()` idiom.
- Added `WriterCommandOutputTest.printMessageAppendsNewlineToMessageOutput` to lock in the newline behavior.
- `mvn clean verify` is green: 317 unit tests + 70 integration/e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)